### PR TITLE
Change comments color to be slightly lighter

### DIFF
--- a/scripts/config/theme.yaml
+++ b/scripts/config/theme.yaml
@@ -292,14 +292,14 @@ attributes:
     italic: always
   DEFAULT_ATTRIBUTE: whiskey
   DEFAULT_BLOCK_COMMENT:
-    foreground: dark
+    foreground: 7c8391
     italic: theme
   DEFAULT_CLASS_NAME: chalky
   DEFAULT_CLASS_REFERENCE: chalky
   DEFAULT_COMMA: {}
   DEFAULT_CONSTANT: whiskey
   DEFAULT_DOC_COMMENT:
-    foreground: dark
+    foreground: 7c8391
     italic: theme
   DEFAULT_DOC_COMMENT_TAG: purple
   DEFAULT_DOC_COMMENT_TAG_VALUE: whiskey
@@ -318,7 +318,7 @@ attributes:
   DEFAULT_LABEL:
     bold: always
   DEFAULT_LINE_COMMENT:
-    foreground: dark
+    foreground: 7c8391
     italic: theme
   DEFAULT_METADATA:
     foreground: chalky


### PR DESCRIPTION
Thanks for a nice theme! Here is a slight suggestion from my end.

The previous colors were too dark for me, when working with Java code (with both line comments, Javadoc etc). The purpose of this change is to try and make it slightly more readable, while still retaining a visual difference from regular identifiers.

Before the change, here is what the One Dark theme looks like on my machine:

![image](https://user-images.githubusercontent.com/630613/65221620-0c860400-dac6-11e9-9607-68a396224fc3.png)

With the change, the comments are slightly more readable:

![image](https://user-images.githubusercontent.com/630613/65221707-3ccda280-dac6-11e9-862c-df118d580623.png)

I wonder if it's best to change it like this, or to change/add a new variable in `scripts/config/colors/normal.yaml` instead. Your thoughts on this?

----

Future improvements in this area could be to use a different color for `DEFAULT_DOC_COMMENT` than for other comments, which is how e.g. Darcula does it. For us working with Java code, this is quite useful since Javadoc comments are more publicly facing than regular line/block comments.