### PR TITLE
Live Configurable Theme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 2

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,7 @@ repositories {
 }
 
 intellij {
-    version '2020.1'
-    type 'IU'
+    version 'LATEST-EAP-SNAPSHOT'
     alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'org.jetbrains.intellij' version '0.4.7'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id "org.jlleitschuh.gradle.ktlint" version "8.2.0"
 }
 
 group 'com.markskelton'
@@ -10,9 +12,18 @@ repositories {
 }
 
 intellij {
-    version 'LATEST-EAP-SNAPSHOT'
+    version '2020.1'
+    type 'IU'
     alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 
 patchPluginXml {
     sinceBuild '191'

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -118,6 +118,10 @@ class Builder:
         scheme.attrib['parent_scheme'] = self.yaml['parent-scheme']
         scheme.attrib['version'] = '142'
 
+        meta = ET.SubElement(scheme, 'metaInfo')
+        oneDarkProperty = ET.SubElement(meta, 'property', name='oneDarkScheme')
+        oneDarkProperty.text = 'bundled'
+
         colors = ET.SubElement(scheme, 'colors')
         for name, value in self.yaml['colors'].items():
             ET.SubElement(colors, 'option', name=name, value=self.get_color(value))
@@ -157,35 +161,11 @@ def write_json(data: dict, output_path: str):
         json.dump(data, output_file)
 
 
-def build_json():
-    input_path = os.path.join(DEST_DIR, 'one_dark.theme.json')
-
-    with open(input_path, 'r') as input_file:
-        data = json.load(input_file, object_pairs_hook=OrderedDict)
-
-    data['name'] = build_theme_name('normal', True)
-    data['editorScheme'] = '/themes/one_dark_italic.xml'
-    write_json(data, 'one_dark_italic')
-
-    data['name'] = build_theme_name('vivid', False)
-    data['editorScheme'] = '/themes/one_dark_vivid.xml'
-    write_json(data, 'one_dark_vivid')
-
-    data['name'] = build_theme_name('vivid', True)
-    data['editorScheme'] = '/themes/one_dark_vivid_italic.xml'
-    write_json(data, 'one_dark_vivid_italic')
-
-
 def main():
     if not os.path.exists(DEST_DIR):
         os.makedirs(DEST_DIR)
 
     Builder('normal', False, '%s.xml' % FILE_NAME).run()
-    Builder('normal', True, '%s_italic.xml' % FILE_NAME).run()
-    Builder('vivid', False, '%s_vivid.xml' % FILE_NAME).run()
-    Builder('vivid', True, '%s_vivid_italic.xml' % FILE_NAME).run()
-
-    build_json()
 
     print('Theme files generated!')
 

--- a/src/main/kotlin/com/markskelton/Extensions.kt
+++ b/src/main/kotlin/com/markskelton/Extensions.kt
@@ -3,3 +3,20 @@ package com.markskelton
 import java.util.*
 
 fun <T> T?.toOptional() = Optional.ofNullable(this)
+
+// This is needed to support Android Studio, because I think it
+// Still runs on a Java 8 Runtime, so no fancy Optional interfaces...
+fun <T> Optional<T>.doOrElse(present: (T) -> Unit, notThere: () -> Unit) =
+  this.map {
+    it to true
+  }.map {
+    it.toOptional()
+  }.orElseGet {
+    (null to false).toOptional()
+  }.ifPresent {
+    if (it.second) {
+      present(it.first)
+    } else {
+      notThere()
+    }
+  }

--- a/src/main/kotlin/com/markskelton/Extensions.kt
+++ b/src/main/kotlin/com/markskelton/Extensions.kt
@@ -1,0 +1,5 @@
+package com.markskelton
+
+import java.util.*
+
+fun <T> T?.toOptional() = Optional.ofNullable(this)

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -8,6 +8,6 @@ import com.markskelton.legacy.LegacyMigration
 class OneDarkTheme : StartupActivity, DumbAware {
   override fun runActivity(project: Project) {
     LegacyMigration.migrateIfNecessary()
-    OneDarkThemeManager.registerStartup()
+    OneDarkThemeManager.registerStartup(project)
   }
 }

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -1,2 +1,12 @@
 package com.markskelton
 
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+
+class OneDarkTheme : StartupActivity, DumbAware {
+  override fun runActivity(project: Project) {
+    OneDarkThemeManager.registerStartup()
+  }
+}
+

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -3,9 +3,11 @@ package com.markskelton
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import com.markskelton.legacy.LegacyMigration
 
 class OneDarkTheme : StartupActivity, DumbAware {
   override fun runActivity(project: Project) {
+    LegacyMigration.migrateIfNecessary()
     OneDarkThemeManager.registerStartup()
   }
 }

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -1,0 +1,2 @@
+package com.markskelton
+

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -11,4 +11,3 @@ class OneDarkTheme : StartupActivity, DumbAware {
     OneDarkThemeManager.registerStartup()
   }
 }
-

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -21,7 +21,7 @@ object OneDarkThemeManager {
 
   fun registerStartup(project: Project) {
     if (!this::messageBus.isInitialized) {
-      attemptToDisplayUpdates(project)
+      attemptToDisplayUpdates()
 
       applyConfigurableTheme()
 
@@ -29,10 +29,12 @@ object OneDarkThemeManager {
     }
   }
 
-  private fun attemptToDisplayUpdates(project: Project) {
+  private fun attemptToDisplayUpdates() {
     if (ThemeSettings.instance.version != CURRENT_VERSION) {
       ThemeSettings.instance.version = CURRENT_VERSION
-      Notifications.displayUpdateNotification(project)
+      ApplicationManager.getApplication().invokeLater {
+        Notifications.displayUpdateNotification()
+      }
     }
   }
 

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -1,5 +1,7 @@
 package com.markskelton
 
+import com.intellij.ide.ui.laf.LafManagerImpl
+import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBusConnection
 import com.markskelton.settings.THEME_CONFIG_TOPIC
@@ -14,9 +16,19 @@ object OneDarkThemeManager {
       messageBus = ApplicationManager.getApplication().messageBus.connect()
       messageBus.subscribe(THEME_CONFIG_TOPIC, object : ThemeConfigListener {
         override fun themeConfigUpdated(themeSettings: ThemeSettings) {
-          println("Theme settings changed! $themeSettings")
+          if (isCurrentTheme()) {
+            LafManagerImpl.getInstance().setCurrentLookAndFeel(
+              ThemeConstructor.constructNewTheme(themeSettings)
+            )
+          }
         }
       })
     }
+  }
+
+  fun isCurrentTheme(): Boolean {
+    val currentLaf = LafManagerImpl.getInstance().currentLookAndFeel
+    return currentLaf is UIThemeBasedLookAndFeelInfo &&
+      currentLaf.theme.id == "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3"
   }
 }

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -7,8 +7,6 @@ import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBusConnection
-import com.markskelton.legacy.LegacyMigration.isLegacyTheme
-import com.markskelton.legacy.LegacyMigration.migrateAndNotifyUserOfDeprecation
 import com.markskelton.notification.CURRENT_VERSION
 import com.markskelton.notification.Notifications
 import com.markskelton.settings.THEME_CONFIG_TOPIC
@@ -56,7 +54,6 @@ object OneDarkThemeManager {
         when {
           currentLaf !is TempUIThemeBasedLookAndFeelInfo &&
             isOneDarkTheme(currentLaf) -> setOneDarkTheme()
-          isLegacyTheme(currentLaf) -> migrateAndNotifyUserOfDeprecation()
         }
       }
     })

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -7,7 +7,7 @@ import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBusConnection
 import com.markskelton.legacy.LegacyMigration.isLegacyTheme
-import com.markskelton.legacy.LegacyMigration.notifyUserOfDeprecation
+import com.markskelton.legacy.LegacyMigration.migrateAndNotifyUserOfDeprecation
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeConfigListener
 import com.markskelton.settings.ThemeSettings
@@ -36,7 +36,7 @@ object OneDarkThemeManager {
           when {
             currentLaf !is TempUIThemeBasedLookAndFeelInfo &&
               isOneDarkTheme(currentLaf) -> setOneDarkTheme()
-            isLegacyTheme(currentLaf) -> notifyUserOfDeprecation()
+            isLegacyTheme(currentLaf) -> migrateAndNotifyUserOfDeprecation()
           }
         }
       })

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -1,6 +1,7 @@
 package com.markskelton
 
 import com.intellij.ide.ui.laf.LafManagerImpl
+import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBusConnection
@@ -10,6 +11,7 @@ import com.markskelton.settings.ThemeSettings
 
 object OneDarkThemeManager {
   private lateinit var messageBus: MessageBusConnection
+  const val ONE_DARK_ID = "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3"
 
   fun registerStartup() {
     if (!this::messageBus.isInitialized) {
@@ -26,9 +28,10 @@ object OneDarkThemeManager {
     }
   }
 
-  fun isCurrentTheme(): Boolean {
-    val currentLaf = LafManagerImpl.getInstance().currentLookAndFeel
-    return currentLaf is UIThemeBasedLookAndFeelInfo &&
-      currentLaf.theme.id == "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3"
-  }
+  fun isCurrentTheme(): Boolean =
+    when (val currentLaf = LafManagerImpl.getInstance().currentLookAndFeel) {
+      is UIThemeBasedLookAndFeelInfo -> currentLaf.theme.id == ONE_DARK_ID
+      is TempUIThemeBasedLookAndFeelInfo -> currentLaf.theme.id == ONE_DARK_ID
+      else -> false
+    }
 }

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -6,6 +6,7 @@ import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBusConnection
+import com.markskelton.legacy.LegacyMigration
 import com.markskelton.legacy.LegacyMigration.isLegacyTheme
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeConfigListener
@@ -31,28 +32,29 @@ object OneDarkThemeManager {
 
       messageBus.subscribe(LafManagerListener.TOPIC, LafManagerListener {
         val currentLaf = it.currentLookAndFeel
-        if (currentLaf is UIThemeBasedLookAndFeelInfo &&
-          currentLaf !is TempUIThemeBasedLookAndFeelInfo
-          && isOneDarkTheme(currentLaf)) {
-          setConstructedOneDarkTheme()
+        if (currentLaf is UIThemeBasedLookAndFeelInfo) {
+          when {
+            currentLaf !is TempUIThemeBasedLookAndFeelInfo &&
+              isOneDarkTheme(currentLaf) -> setOneDarkTheme()
+            isLegacyTheme(currentLaf) -> LegacyMigration.notifyUserOfDeprecation()
+          }
         }
       })
     }
   }
 
-  private fun isOneDarkTheme(uiThemeBasedLookAndFeelInfo: UIThemeBasedLookAndFeelInfo): Boolean {
-    return uiThemeBasedLookAndFeelInfo.theme.id == ONE_DARK_ID || isLegacyTheme(uiThemeBasedLookAndFeelInfo)
-  }
+  private fun isOneDarkTheme(uiThemeBasedLookAndFeelInfo: UIThemeBasedLookAndFeelInfo): Boolean =
+    uiThemeBasedLookAndFeelInfo.theme.id == ONE_DARK_ID
 
   private fun applyConfigurableTheme() {
     if (isCurrentTheme()) {
-      setConstructedOneDarkTheme()
+      setOneDarkTheme()
     }
   }
 
-  private fun setConstructedOneDarkTheme() {
+  private fun setOneDarkTheme() {
     LafManagerImpl.getInstance().setCurrentLookAndFeel(
-      ThemeConstructor.constructNewTheme(ThemeSettings.instance)
+      ThemeConstructor.useExistingTheme()
     )
   }
 

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -5,9 +5,12 @@ import com.intellij.ide.ui.laf.LafManagerImpl
 import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBusConnection
 import com.markskelton.legacy.LegacyMigration.isLegacyTheme
 import com.markskelton.legacy.LegacyMigration.migrateAndNotifyUserOfDeprecation
+import com.markskelton.notification.CURRENT_VERSION
+import com.markskelton.notification.Notifications
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeConfigListener
 import com.markskelton.settings.ThemeSettings
@@ -16,8 +19,12 @@ object OneDarkThemeManager {
   private lateinit var messageBus: MessageBusConnection
   const val ONE_DARK_ID = "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3"
 
-  fun registerStartup() {
+  fun registerStartup(project: Project) {
     if (!this::messageBus.isInitialized) {
+      if (ThemeSettings.instance.version != CURRENT_VERSION) {
+        ThemeSettings.instance.version = CURRENT_VERSION
+        Notifications.displayUpdateNotification(project)
+      }
       applyConfigurableTheme()
       messageBus = ApplicationManager.getApplication().messageBus.connect()
       messageBus.subscribe(THEME_CONFIG_TOPIC, object : ThemeConfigListener {

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -6,8 +6,8 @@ import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBusConnection
-import com.markskelton.legacy.LegacyMigration
 import com.markskelton.legacy.LegacyMigration.isLegacyTheme
+import com.markskelton.legacy.LegacyMigration.notifyUserOfDeprecation
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeConfigListener
 import com.markskelton.settings.ThemeSettings
@@ -36,7 +36,7 @@ object OneDarkThemeManager {
           when {
             currentLaf !is TempUIThemeBasedLookAndFeelInfo &&
               isOneDarkTheme(currentLaf) -> setOneDarkTheme()
-            isLegacyTheme(currentLaf) -> LegacyMigration.notifyUserOfDeprecation()
+            isLegacyTheme(currentLaf) -> notifyUserOfDeprecation()
           }
         }
       })

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -1,0 +1,22 @@
+package com.markskelton
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.util.messages.MessageBusConnection
+import com.markskelton.settings.THEME_CONFIG_TOPIC
+import com.markskelton.settings.ThemeConfigListener
+import com.markskelton.settings.ThemeSettings
+
+object OneDarkThemeManager {
+  private lateinit var messageBus: MessageBusConnection
+
+  fun registerStartup() {
+    if (!this::messageBus.isInitialized) {
+      messageBus = ApplicationManager.getApplication().messageBus.connect()
+      messageBus.subscribe(THEME_CONFIG_TOPIC, object : ThemeConfigListener {
+        override fun themeConfigUpdated(themeSettings: ThemeSettings) {
+          println("Theme settings changed! $themeSettings")
+        }
+      })
+    }
+  }
+}

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -1,5 +1,7 @@
 package com.markskelton
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.intellij.ide.ui.laf.LafManagerImpl
 import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
@@ -19,6 +21,7 @@ import java.nio.file.Paths
 import javax.swing.UIManager
 
 object ThemeConstructor {
+  private val gson = Gson()
 
   fun constructNewTheme(newSettings: ThemeSettings): UIManager.LookAndFeelInfo {
     val oneDarkLAF = LafManagerImpl.getInstance().installedLookAndFeels
@@ -67,7 +70,10 @@ object ThemeConstructor {
   }
 
   private fun getColorPalette(themeSettings: ThemeSettings): Map<String, String> {
-    TODO("Not yet implemented")
+    val selectedPalette = if(themeSettings.isVivid) "vivid" else "normal"
+    return gson.fromJson(this::class.java.getResourceAsStream(
+      "$selectedPalette.palette.json"
+    ).reader(), object: TypeToken<Map<String, String>>() {}.type)
   }
 
   private fun getAssetsDirectory(): Path {

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -73,7 +73,7 @@ object ThemeConstructor {
   private fun getUpdatedEditorScheme(themeSettings: ThemeSettings): Path {
     val assetsDirectory = getAssetsDirectory()
     cleanDirectory(assetsDirectory)
-    // Intellij caches files, and will not update if you change the file
+    // Intellij caches files, and will not update if you change the contents of the file
     val newEditorSchemeFile = Paths.get(
       assetsDirectory.toAbsolutePath().toString(),
       "$ONE_DARK_FILE_PREFIX${UUID.randomUUID()}.xml"
@@ -125,7 +125,7 @@ object ThemeConstructor {
               it.attributes()["value"] = buildReplacement(replacementColor, value, end)
             } else if (value?.startsWith('%') == true) {
               val (_, fontVariant) = extractValueFromTemplateString(value, '%') { fontSpec ->
-                val fontSpecifications = fontSpec.split("$")
+                val fontSpecifications = fontSpec.split('$')
                 val shouldEffectBeBold = isEffectBold(fontSpecifications, themeSettings)
                 val shouldEffectBeItalic = isEffectItalic(fontSpecifications, themeSettings)
                 when {

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -3,9 +3,18 @@ package com.markskelton
 import com.intellij.ide.ui.laf.LafManagerImpl
 import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
 import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.markskelton.OneDarkThemeManager.ONE_DARK_ID
 import com.markskelton.settings.ThemeSettings
+import groovy.util.Node
+import groovy.util.XmlNodePrinter
+import java.io.BufferedOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import javax.swing.UIManager
 
@@ -17,10 +26,65 @@ object ThemeConstructor {
       .first {
         it.theme.id == ONE_DARK_ID
       }
-    val editorPath = Paths.get("/home/alex/workspace/doki-theme-jetbrains/src/main/resources/doki/themes/danganronpa/Mioda_Ibuki_Dark.xml")
     return TempUIThemeBasedLookAndFeelInfo(
       oneDarkLAF.theme,
-      VfsUtil.findFile(editorPath, true)
+      VfsUtil.findFile(getUpdatedEditorScheme(newSettings), true)
     )
+  }
+
+  private fun getUpdatedEditorScheme(themeSettings: ThemeSettings): Path {
+    val newEditorSchemeFile = Paths.get(getAssetsDirectory().toAbsolutePath().toString(), "one_dark.xml")
+    buildNewEditorScheme(themeSettings, newEditorSchemeFile)
+    return newEditorSchemeFile
+  }
+
+  private fun buildNewEditorScheme(themeSettings: ThemeSettings, newSchemeFile: Path) {
+    val colorPalette = getColorPalette(themeSettings)
+    val fontVariants = getFontVariants(themeSettings)
+    val editorTemplate = getEditorXMLTemplate()
+    val updatedScheme = applySettingsToTemplate(
+      editorTemplate,
+      fontVariants,
+      colorPalette
+    )
+    writeXmlToFile(newSchemeFile, updatedScheme)
+  }
+
+  private fun applySettingsToTemplate(
+    editorTemplate: Node,
+    fontVariants: Map<String, String>,
+    colorPalette: Map<String, String>
+  ): Node {
+    TODO("Not yet implemented")
+  }
+
+  private fun getEditorXMLTemplate(): Node {
+    TODO("Not yet implemented")
+  }
+
+  private fun getFontVariants(themeSettings: ThemeSettings): Map<String, String> {
+    TODO("Not yet implemented")
+  }
+
+  private fun getColorPalette(themeSettings: ThemeSettings): Map<String, String> {
+    TODO("Not yet implemented")
+  }
+
+  private fun getAssetsDirectory(): Path {
+    val configDirectory = Paths.get(PathManager.getConfigPath(), "oneDarkAssets")
+    if (Files.notExists(configDirectory)) {
+      Files.createDirectories(configDirectory)
+    }
+    return configDirectory
+  }
+
+  private fun writeXmlToFile(pluginXml: Path, parsedPluginXml: Node) {
+    Files.newOutputStream(pluginXml).use {
+      val outputStream = BufferedOutputStream(it)
+      val writer = PrintWriter(OutputStreamWriter(outputStream, StandardCharsets.UTF_8))
+      val printer = XmlNodePrinter(writer)
+      printer.isPreserveWhitespace = true
+      printer.print(parsedPluginXml)
+    }
   }
 }

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -113,7 +113,7 @@ object ThemeConstructor {
       .forEach {
         when (it.name()) {
           "scheme" -> {
-            it.attributes().replace("name", "One Dark")
+            it.attributes().replace("name", "One Dark Generated")
           }
           "option" -> {
             val value = it.attribute("value") as? String

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -123,10 +123,16 @@ object ThemeConstructor {
           }
           "option" -> {
             val value = it.attribute("value") as? String
-            if (value?.contains('$') == true) {
+            if (value?.startsWith('$') == true) {
               val (end, replacementColor) = getReplacementColor(value, '$') { templateColor ->
                 colors[templateColor]
                   ?: throw IllegalArgumentException("$templateColor is not in the color definition for $paletteVariant.")
+              }
+              it.attributes()["value"] = buildReplacement(replacementColor, value, end)
+            } else if (value?.startsWith('%') == true) {
+              val (end, replacementColor) = getReplacementColor(value, '%') { fontSpec ->
+                colors[fontSpec]
+                  ?: throw IllegalArgumentException("$fontSpec is not in the color definition for $paletteVariant.")
               }
               it.attributes()["value"] = buildReplacement(replacementColor, value, end)
             }

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -1,15 +1,26 @@
 package com.markskelton
 
 import com.intellij.ide.ui.laf.LafManagerImpl
+import com.intellij.ide.ui.laf.TempUIThemeBasedLookAndFeelInfo
+import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
+import com.intellij.openapi.vfs.VfsUtil
+import com.markskelton.OneDarkThemeManager.ONE_DARK_ID
 import com.markskelton.settings.ThemeSettings
+import java.nio.file.Paths
 import javax.swing.UIManager
 
 object ThemeConstructor {
 
   fun constructNewTheme(newSettings: ThemeSettings): UIManager.LookAndFeelInfo {
-    val currentLaf = LafManagerImpl.getInstance().currentLookAndFeel
-    return LafManagerImpl.getInstance().installedLookAndFeels.first {
-      it != currentLaf
-    }
+    val oneDarkLAF = LafManagerImpl.getInstance().installedLookAndFeels
+      .filterIsInstance<UIThemeBasedLookAndFeelInfo>()
+      .first {
+        it.theme.id == ONE_DARK_ID
+      }
+    val editorPath = Paths.get("/home/alex/workspace/doki-theme-jetbrains/src/main/resources/doki/themes/danganronpa/Mioda_Ibuki_Dark.xml")
+    return TempUIThemeBasedLookAndFeelInfo(
+      oneDarkLAF.theme,
+      VfsUtil.findFile(editorPath, true)
+    )
   }
 }

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -1,0 +1,15 @@
+package com.markskelton
+
+import com.intellij.ide.ui.laf.LafManagerImpl
+import com.markskelton.settings.ThemeSettings
+import javax.swing.UIManager
+
+object ThemeConstructor {
+
+  fun constructNewTheme(newSettings: ThemeSettings): UIManager.LookAndFeelInfo {
+    val currentLaf = LafManagerImpl.getInstance().currentLookAndFeel
+    return LafManagerImpl.getInstance().installedLookAndFeels.first {
+      it != currentLaf
+    }
+  }
+}

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -20,6 +20,10 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import javax.swing.UIManager
 
+enum class FontVariant(val schemeValue: Int) {
+  BOLD(1), ITALIC(2), BOLD_ITALIC(3), NONE(0)
+}
+
 object ThemeConstructor {
   private val gson = Gson()
 
@@ -55,7 +59,7 @@ object ThemeConstructor {
 
   private fun applySettingsToTemplate(
     editorTemplate: Node,
-    fontVariants: Map<String, String>,
+    fontVariants: FontVariant,
     colorPalette: Map<String, String>
   ): Node {
     TODO("Not yet implemented")
@@ -65,8 +69,13 @@ object ThemeConstructor {
     TODO("Not yet implemented")
   }
 
-  private fun getFontVariants(themeSettings: ThemeSettings): Map<String, String> {
-    TODO("Not yet implemented")
+  private fun getFontVariants(themeSettings: ThemeSettings): FontVariant {
+    return when {
+      themeSettings.isBold && themeSettings.isItalic -> FontVariant.BOLD_ITALIC
+      themeSettings.isBold -> FontVariant.BOLD
+      themeSettings.isItalic -> FontVariant.ITALIC
+      else -> FontVariant.NONE
+    }
   }
 
   private fun getColorPalette(themeSettings: ThemeSettings): Map<String, String> {

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -22,13 +22,17 @@ object LegacyMigration {
   fun isLegacyTheme(laf: UIThemeBasedLookAndFeelInfo): Boolean = legacyThemes.containsKey(laf.theme.id)
 
   fun migrateIfNecessary() {
-    migrateAndNotifyUserOfDeprecation()
+    migrateUser()
   }
 
   fun migrateAndNotifyUserOfDeprecation() {
+    Notifications.displayDeprecationMessage()
+    migrateUser()
+  }
+
+  private fun migrateUser() {
     val legacyTheme = LafManagerImpl.getInstance().currentLookAndFeel
     if (legacyTheme is UIThemeBasedLookAndFeelInfo && isLegacyTheme(legacyTheme)) {
-      Notifications.displayDeprecationMessage()
       LafManagerImpl.getInstance().setCurrentLookAndFeel(LafManagerImpl.getInstance().installedLookAndFeels
         .filterIsInstance<UIThemeBasedLookAndFeelInfo>()
         .first {

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.RoamingType
 import com.markskelton.OneDarkThemeManager
-import com.markskelton.notification.Notifications
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeSettings
 import com.markskelton.toOptional

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -1,0 +1,17 @@
+package com.markskelton.legacy
+
+enum class LegacyThemes {
+ITALIC, VIVID, VIVID_ITALIC
+}
+
+object LegacyMigration {
+  private val legacyThemes = mapOf(
+    "1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" to LegacyThemes.ITALIC,
+    "4b6007f7-b596-4ee2-96f9-968d3d3eb392" to LegacyThemes.VIVID,
+    "4f556d32-83cb-4b8b-9932-c4eccc4ce3af" to LegacyThemes.VIVID_ITALIC
+  )
+
+  fun migrateIfNecessary(){
+    // todo: this!
+  }
+}

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -1,5 +1,7 @@
 package com.markskelton.legacy
 
+import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
+
 enum class LegacyThemes {
 ITALIC, VIVID, VIVID_ITALIC
 }
@@ -10,6 +12,8 @@ object LegacyMigration {
     "4b6007f7-b596-4ee2-96f9-968d3d3eb392" to LegacyThemes.VIVID,
     "4f556d32-83cb-4b8b-9932-c4eccc4ce3af" to LegacyThemes.VIVID_ITALIC
   )
+
+  fun isLegacyTheme(laf: UIThemeBasedLookAndFeelInfo): Boolean = legacyThemes.containsKey(laf.theme.id)
 
   fun migrateIfNecessary() {
     // todo: this!

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -11,7 +11,7 @@ object LegacyMigration {
     "4f556d32-83cb-4b8b-9932-c4eccc4ce3af" to LegacyThemes.VIVID_ITALIC
   )
 
-  fun migrateIfNecessary(){
+  fun migrateIfNecessary() {
     // todo: this!
   }
 }

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -18,4 +18,9 @@ object LegacyMigration {
   fun migrateIfNecessary() {
     // todo: this!
   }
+
+  fun notifyUserOfDeprecation() {
+    // display message
+    // set laf as One One Dark from theme provider
+  }
 }

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -26,7 +26,9 @@ object LegacyMigration {
   }
 
   fun migrateAndNotifyUserOfDeprecation() {
-    Notifications.displayDeprecationMessage()
+    ApplicationManager.getApplication().invokeLater {
+      Notifications.displayDeprecationMessage()
+    }
     migrateUser()
   }
 

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -30,7 +30,7 @@ object Notifications {
     "One Dark Theme",
     NotificationDisplayType.BALLOON,
     false,
-    "One-Dark Theme"
+    "One Dark Theme"
   )
 
   fun displayUpdateNotification() {

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -22,8 +22,6 @@ val UPDATE_MESSAGE: String = """
       Thank you for choosing the One Dark Theme!<br>
 """.trimIndent()
 
-const val CURRENT_VERSION = "4.0.0"
-
 object Notifications {
 
   private val notificationGroup = NotificationGroup(
@@ -33,13 +31,13 @@ object Notifications {
     "One Dark Theme"
   )
 
-  fun displayUpdateNotification() {
+  fun displayUpdateNotification(versionNumber: String) {
     val pluginName =
       getPlugin(
         getPluginOrPlatformByClassName(Notifications::class.java.canonicalName)
       )?.name
     notificationGroup.createNotification(
-      "$pluginName updated to v$CURRENT_VERSION",
+      "$pluginName updated to v$versionNumber",
       UPDATE_MESSAGE,
       NotificationType.INFORMATION,
       NotificationListener.URL_OPENING_LISTENER

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -27,7 +27,7 @@ const val CURRENT_VERSION = "4.0.0"
 object Notifications {
 
   private val notificationGroup = NotificationGroup(
-    "One-Dark Theme",
+    "One Dark Theme",
     NotificationDisplayType.BALLOON,
     false,
     "One-Dark Theme"

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -1,0 +1,69 @@
+package com.markskelton.notification
+
+import com.intellij.ide.plugins.PluginManagerCore.getPlugin
+import com.intellij.ide.plugins.PluginManagerCore.getPluginOrPlatformByClassName
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationDisplayType
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationListener
+import com.intellij.notification.NotificationType
+import com.intellij.notification.SingletonNotificationManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.markskelton.settings.ThemeSettingsUI
+
+val UPDATE_MESSAGE: String = """
+      What's New?<br>
+      <ul>
+        <li>Theme is now configurable through settings.</li>
+      </ul>
+      <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
+      <br>
+      Thank you for choosing the One Dark Theme!<br>
+""".trimIndent()
+
+const val CURRENT_VERSION = "4.0.0"
+
+object Notifications {
+
+  private val notificationManager by lazy {
+    SingletonNotificationManager(
+      NotificationGroup(
+        "One-Dark Notifications",
+        NotificationDisplayType.STICKY_BALLOON, true
+      ),
+      NotificationType.INFORMATION
+    )
+  }
+
+
+  fun displayUpdateNotification(project: Project) {
+    val pluginName =
+      getPlugin(
+        getPluginOrPlatformByClassName(Notifications::class.java.canonicalName)
+      )?.name
+    notificationManager.notify(
+      "$pluginName updated to v$CURRENT_VERSION",
+      UPDATE_MESSAGE,
+      project,
+      NotificationListener.URL_OPENING_LISTENER
+    )
+  }
+
+  fun displayDeprecationMessage() {
+    notificationManager.notify(
+      "Theme is Deprecated",
+      """The other variants of the One-Dark theme are currently deprecated. 
+|Please use the '${ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME}' menu in the settings to configure the theme""".trimMargin(),
+        action = SettingsAction("Show Settings")
+    )
+  }
+}
+
+class SettingsAction(text: String): NotificationAction(text) {
+  override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+    ShowSettingsUtil.getInstance().showSettingsDialog(e.project, ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME)
+  }
+}

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -8,10 +8,8 @@ import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
-import com.intellij.notification.SingletonNotificationManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
-import com.intellij.openapi.project.Project
 import com.markskelton.settings.ThemeSettingsUI
 
 val UPDATE_MESSAGE: String = """
@@ -28,36 +26,36 @@ const val CURRENT_VERSION = "4.0.0"
 
 object Notifications {
 
-  private val notificationManager by lazy {
-    SingletonNotificationManager(
-      NotificationGroup(
-        "One-Dark Notifications",
-        NotificationDisplayType.STICKY_BALLOON, true
-      ),
-      NotificationType.INFORMATION
-    )
-  }
+  private val notificationGroup = NotificationGroup(
+    "One-Dark Theme",
+    NotificationDisplayType.BALLOON,
+    false,
+    "One-Dark Theme"
+  )
 
-  fun displayUpdateNotification(project: Project) {
+  fun displayUpdateNotification() {
     val pluginName =
       getPlugin(
         getPluginOrPlatformByClassName(Notifications::class.java.canonicalName)
       )?.name
-    notificationManager.notify(
+    notificationGroup.createNotification(
       "$pluginName updated to v$CURRENT_VERSION",
       UPDATE_MESSAGE,
-      project,
+      NotificationType.INFORMATION,
       NotificationListener.URL_OPENING_LISTENER
-    )
+    ).notify(null)
   }
 
   fun displayDeprecationMessage() {
-    notificationManager.notify(
+    notificationGroup.createNotification(
       "Theme is Deprecated",
       """The other variants of the One-Dark theme are currently deprecated. 
-|Please use the '${ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME}' menu in the settings to configure the theme""".trimMargin(),
-        action = SettingsAction("Show Settings")
-    )
+        |For convenience, this theme's settings have been automatically applied. 
+|Please use the '${ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME}' menu in the settings to configure One-Dark in the future.""".trimMargin(),
+      NotificationType.WARNING,
+      null
+    ).addAction(SettingsAction("Show Settings"))
+      .notify(null)
   }
 }
 

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -38,7 +38,6 @@ object Notifications {
     )
   }
 
-
   fun displayUpdateNotification(project: Project) {
     val pluginName =
       getPlugin(
@@ -62,7 +61,7 @@ object Notifications {
   }
 }
 
-class SettingsAction(text: String): NotificationAction(text) {
+class SettingsAction(text: String) : NotificationAction(text) {
   override fun actionPerformed(e: AnActionEvent, notification: Notification) {
     ShowSettingsUtil.getInstance().showSettingsDialog(e.project, ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME)
   }

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -43,18 +43,8 @@ object Notifications {
       UPDATE_MESSAGE,
       NotificationType.INFORMATION,
       NotificationListener.URL_OPENING_LISTENER
-    ).notify(null)
-  }
-
-  fun displayDeprecationMessage() {
-    notificationGroup.createNotification(
-      "Theme is Deprecated",
-      """The other variants of the One-Dark theme are currently deprecated. 
-        |For convenience, this theme's settings have been automatically applied. 
-|Please use the '${ThemeSettingsUI.THEME_SETTINGS_DISPLAY_NAME}' menu in the settings to configure One-Dark in the future.""".trimMargin(),
-      NotificationType.WARNING,
-      null
-    ).addAction(SettingsAction("Show Settings"))
+    )
+      .addAction(SettingsAction("Show Settings"))
       .notify(null)
   }
 }

--- a/src/main/kotlin/com/markskelton/settings/ThemeConfigListener.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeConfigListener.kt
@@ -1,0 +1,11 @@
+package com.markskelton.settings
+
+import com.intellij.util.messages.Topic
+import java.util.*
+
+val THEME_CONFIG_TOPIC: Topic<ThemeConfigListener> =
+  Topic(ThemeConfigListener::class.java)
+
+interface ThemeConfigListener : EventListener {
+  fun themeConfigUpdated(themeSettings: ThemeSettings)
+}

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -1,0 +1,37 @@
+package com.markskelton.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "OneDarkConfig",
+    storages = [Storage("one_dark_config.xml")]
+)
+class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
+  companion object {
+    val instance: ThemeSettings
+      get() = ServiceManager.getService(ThemeSettings::class.java)
+  }
+
+  var version: String = "0.0.0"
+  var isBold: Boolean = false
+  var isVivid: Boolean = false
+  var isItalic: Boolean = false
+
+  override fun getState(): ThemeSettings? =
+      XmlSerializerUtil.createCopy(this)
+
+  override fun loadState(state: ThemeSettings) {
+    XmlSerializerUtil.copyBean(state, this)
+  }
+
+  fun asJson(): Map<String, Any> = mapOf(
+      "version" to version,
+      "isBold" to isBold,
+      "isVivid" to isVivid,
+      "isItalic" to isItalic
+  )
+}

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -22,7 +22,6 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
         instance.isItalic
       )
     }
-
   }
 
   var version: String = "0.0.0"

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -28,6 +28,7 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   var isBold: Boolean = false
   var isVivid: Boolean = false
   var isItalic: Boolean = false
+  var customSchemeSet: Boolean = false
 
   override fun getState(): ThemeSettings? =
       XmlSerializerUtil.createCopy(this)

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -14,6 +14,15 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   companion object {
     val instance: ThemeSettings
       get() = ServiceManager.getService(ThemeSettings::class.java)
+
+    fun constructSettingModel(): ThemeSettingsModel {
+      return ThemeSettingsModel(
+        instance.isBold,
+        instance.isVivid,
+        instance.isItalic
+      )
+    }
+
   }
 
   var version: String = "0.0.0"

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -19,7 +19,7 @@ data class ThemeSettingsModel(
 class ThemeSettingsUI : DumbAware, SearchableConfigurable {
 
   companion object {
-    const val THEME_SETTINGS_DISPLAY_NAME = "One Dark Theme Settings"
+    const val THEME_SETTINGS_DISPLAY_NAME = "One Dark Theme"
     private const val REPOSITORY = "https://github.com/one-dark/jetbrains-one-dark-theme"
     private val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md")
     private val ISSUES_URI = URI("$REPOSITORY/issues")

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -8,7 +8,6 @@ import com.intellij.ui.layout.panel
 import com.markskelton.settings.ThemeSettings.Companion.constructSettingModel
 import java.net.URI
 import javax.swing.JComponent
-import javax.swing.JLabel
 
 data class ThemeSettingsModel(
   var isBold: Boolean,
@@ -29,7 +28,7 @@ class ThemeSettingsUI : SearchableConfigurable {
   override fun getId(): String = "com.markskelton.ThemeSettings"
 
   override fun getDisplayName(): String =
-      THEME_SETTINGS_DISPLAY_NAME
+    THEME_SETTINGS_DISPLAY_NAME
 
   private val initialThemeSettingsModel = constructSettingModel()
 
@@ -42,7 +41,7 @@ class ThemeSettingsUI : SearchableConfigurable {
   override fun apply() {
     persistChanges()
     ApplicationManager.getApplication().messageBus.syncPublisher(
-        THEME_CONFIG_TOPIC
+      THEME_CONFIG_TOPIC
     ).themeConfigUpdated(ThemeSettings.instance)
   }
 
@@ -65,53 +64,44 @@ class ThemeSettingsUI : SearchableConfigurable {
   }
 
   override fun createComponent(): JComponent? =
-      createSettingsPane()
+    createSettingsPane()
 
-  private fun createSettingsPane(): DialogPanel {
-    val directoryIcon = JLabel()
-//    directoryIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/directoryIcon.png"))
-    val fileIcon = JLabel()
-//    fileIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/fileIcon.png"))
-    val psiIcon = JLabel()
-//    psiIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/psiIcon.png"))
-    return panel {
+  private fun createSettingsPane(): DialogPanel =
+    panel {
       titledRow("Main Settings") {
+//        row {
+//          cell {
+//            checkBox(
+//              "Bold Characters",
+//              themeSettingsModel.isBold,
+//              comment = "Uses bold fonts for certain language keywords",
+//              actionListener = { _, component ->
+//                themeSettingsModel.isBold = component.isSelected
+//              }
+//            )
+//          }
+//        }
         row {
           cell {
-            directoryIcon()
             checkBox(
-                "Bold Characters",
-                themeSettingsModel.isBold,
-                comment = "Uses bold fonts for certain language keywords",
-                actionListener = { _, component ->
-                  themeSettingsModel.isBold = component.isSelected
-                }
+              "Italic Characters",
+              themeSettingsModel.isItalic,
+              comment = "Uses italic font for language keywords and comments",
+              actionListener = { _, component ->
+                themeSettingsModel.isItalic = component.isSelected
+              }
             )
           }
         }
         row {
           cell {
-            fileIcon()
             checkBox(
-                "Italic Characters",
-                themeSettingsModel.isItalic,
-                comment = "Uses italic font for language keywords and comments",
-                actionListener = { _, component ->
-                  themeSettingsModel.isItalic = component.isSelected
-                }
-            )
-          }
-        }
-        row {
-          cell {
-            psiIcon()
-            checkBox(
-                "Vivid Pallette",
-                themeSettingsModel.isVivid,
-                comment = "Uses the One-Dark vivid color pallette",
-                actionListener = { _, component ->
-                  themeSettingsModel.isVivid = component.isSelected
-                }
+              "Vivid Pallette",
+              themeSettingsModel.isVivid,
+              comment = "Uses the One-Dark vivid color pallette",
+              actionListener = { _, component ->
+                themeSettingsModel.isVivid = component.isSelected
+              }
             )
           }
         }
@@ -132,7 +122,6 @@ class ThemeSettingsUI : SearchableConfigurable {
         }
       }
     }
-  }
 }
 
 fun <T> registerSettingsChange(setValue: T, getStoredValue: () -> T, onChanged: (T) -> Unit) {

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -23,7 +23,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
     private const val REPOSITORY = "https://github.com/one-dark/jetbrains-one-dark-theme"
     private val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md#changelog")
     private val ISSUES_URI = URI("$REPOSITORY/issues")
-    private val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme")
+    private val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme/reviews")
   }
 
   override fun getId(): String = "com.markskelton.ThemeSettings"
@@ -116,7 +116,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
             button("View Changelog") {
               browse(CHANGELOG_URI)
             }
-            button("Marketplace Homepage") {
+            button("Leave a Review") {
               browse(MARKETPLACE_URI)
             }
           }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -110,7 +110,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
       titledRow("Miscellaneous Items") {
         row {
           cell {
-            button("View Issues") {
+            button("Report an Issue") {
               browse(ISSUES_URI)
             }
             button("View Changelog") {

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -49,9 +49,9 @@ class ThemeSettingsUI : SearchableConfigurable {
   }
 
   override fun createComponent(): JComponent? =
-      createMaterialIconsPane()
+      createSettingsPane()
 
-  private fun createMaterialIconsPane(): DialogPanel {
+  private fun createSettingsPane(): DialogPanel {
     val directoryIcon = JLabel()
 //    directoryIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/directoryIcon.png"))
     val fileIcon = JLabel()

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -31,7 +31,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
   override fun getDisplayName(): String =
     THEME_SETTINGS_DISPLAY_NAME
 
-  private val initialThemeSettingsModel = constructSettingModel()
+  private var initialThemeSettingsModel = constructSettingModel()
 
   private val themeSettingsModel = initialThemeSettingsModel.copy()
 
@@ -44,6 +44,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
     ApplicationManager.getApplication().messageBus.syncPublisher(
       THEME_CONFIG_TOPIC
     ).themeConfigUpdated(ThemeSettings.instance)
+    initialThemeSettingsModel = themeSettingsModel.copy()
   }
 
   private fun persistChanges() {

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -10,9 +10,9 @@ import javax.swing.JComponent
 import javax.swing.JLabel
 
 data class ThemeSettingsModel(
-    var isBold: Boolean,
-    var isVivid: Boolean,
-    var isItalic: Boolean
+  var isBold: Boolean,
+  var isVivid: Boolean,
+  var isItalic: Boolean
 )
 
 class ThemeSettingsUI : SearchableConfigurable {
@@ -138,9 +138,8 @@ class ThemeSettingsUI : SearchableConfigurable {
   }
 }
 
-
 fun <T> registerSettingsChange(setValue: T, getStoredValue: () -> T, onChanged: (T) -> Unit) {
-  if(getStoredValue() != setValue) {
+  if (getStoredValue() != setValue) {
     onChanged(setValue)
   }
 }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.panel
+import com.markskelton.settings.ThemeSettings.Companion.constructSettingModel
 import java.net.URI
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -30,11 +31,7 @@ class ThemeSettingsUI : SearchableConfigurable {
   override fun getDisplayName(): String =
       THEME_SETTINGS_DISPLAY_NAME
 
-  private val initialThemeSettingsModel = ThemeSettingsModel(
-      ThemeSettings.instance.isBold,
-      ThemeSettings.instance.isVivid,
-      ThemeSettings.instance.isItalic
-  )
+  private val initialThemeSettingsModel = constructSettingModel()
 
   private val themeSettingsModel = initialThemeSettingsModel.copy()
 

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -97,7 +97,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
         row {
           cell {
             checkBox(
-              "Vivid Pallette",
+              "Vivid Palette",
               themeSettingsModel.isVivid,
               comment = "Uses the One-Dark vivid color pallette",
               actionListener = { _, component ->

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -3,6 +3,7 @@ package com.markskelton.settings
 import com.intellij.ide.BrowserUtil.browse
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.panel
 import com.markskelton.settings.ThemeSettings.Companion.constructSettingModel
@@ -15,14 +16,14 @@ data class ThemeSettingsModel(
   var isItalic: Boolean
 )
 
-class ThemeSettingsUI : SearchableConfigurable {
+class ThemeSettingsUI : DumbAware, SearchableConfigurable {
 
   companion object {
     const val THEME_SETTINGS_DISPLAY_NAME = "One Dark Theme Settings"
     private const val REPOSITORY = "https://github.com/one-dark/jetbrains-one-dark-theme"
-    val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md")
-    val ISSUES_URI = URI("$REPOSITORY/issues")
-    val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme")
+    private val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md")
+    private val ISSUES_URI = URI("$REPOSITORY/issues")
+    private val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme")
   }
 
   override fun getId(): String = "com.markskelton.ThemeSettings"

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -43,9 +43,28 @@ class ThemeSettingsUI : SearchableConfigurable {
   }
 
   override fun apply() {
+    persistChanges()
     ApplicationManager.getApplication().messageBus.syncPublisher(
         THEME_CONFIG_TOPIC
     ).themeConfigUpdated(ThemeSettings.instance)
+  }
+
+  private fun persistChanges() {
+    registerSettingsChange(themeSettingsModel.isBold, {
+      ThemeSettings.instance.isBold
+    }) {
+      ThemeSettings.instance.isBold = it
+    }
+    registerSettingsChange(themeSettingsModel.isVivid, {
+      ThemeSettings.instance.isVivid
+    }) {
+      ThemeSettings.instance.isVivid = it
+    }
+    registerSettingsChange(themeSettingsModel.isItalic, {
+      ThemeSettings.instance.isItalic
+    }) {
+      ThemeSettings.instance.isItalic = it
+    }
   }
 
   override fun createComponent(): JComponent? =
@@ -116,5 +135,12 @@ class ThemeSettingsUI : SearchableConfigurable {
         }
       }
     }
+  }
+}
+
+
+fun <T> registerSettingsChange(setValue: T, getStoredValue: () -> T, onChanged: (T) -> Unit) {
+  if(getStoredValue() != setValue) {
+    onChanged(setValue)
   }
 }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -1,0 +1,120 @@
+package com.markskelton.settings
+
+import com.intellij.ide.BrowserUtil.browse
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.layout.panel
+import java.net.URI
+import javax.swing.JComponent
+import javax.swing.JLabel
+
+data class ThemeSettingsModel(
+    var isBold: Boolean,
+    var isVivid: Boolean,
+    var isItalic: Boolean
+)
+
+class ThemeSettingsUI : SearchableConfigurable {
+
+  companion object {
+    const val THEME_SETTINGS_DISPLAY_NAME = "One Dark Theme Settings"
+    private const val REPOSITORY = "https://github.com/one-dark/jetbrains-one-dark-theme"
+    val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md")
+    val ISSUES_URI = URI("$REPOSITORY/issues")
+    val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme")
+  }
+
+  override fun getId(): String = "com.markskelton.ThemeSettings"
+
+  override fun getDisplayName(): String =
+      THEME_SETTINGS_DISPLAY_NAME
+
+  private val initialThemeSettingsModel = ThemeSettingsModel(
+      ThemeSettings.instance.isBold,
+      ThemeSettings.instance.isVivid,
+      ThemeSettings.instance.isItalic
+  )
+
+  private val themeSettingsModel = initialThemeSettingsModel.copy()
+
+  override fun isModified(): Boolean {
+    return initialThemeSettingsModel != themeSettingsModel
+  }
+
+  override fun apply() {
+    ApplicationManager.getApplication().messageBus.syncPublisher(
+        THEME_CONFIG_TOPIC
+    ).themeConfigUpdated(ThemeSettings.instance)
+  }
+
+  override fun createComponent(): JComponent? =
+      createMaterialIconsPane()
+
+  private fun createMaterialIconsPane(): DialogPanel {
+    val directoryIcon = JLabel()
+//    directoryIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/directoryIcon.png"))
+    val fileIcon = JLabel()
+//    fileIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/fileIcon.png"))
+    val psiIcon = JLabel()
+//    psiIcon.icon = ImageIcon(javaClass.getResource("/icons/settings/psiIcon.png"))
+    return panel {
+      titledRow("Main Settings") {
+        row {
+          cell {
+            directoryIcon()
+            checkBox(
+                "Bold Characters",
+                themeSettingsModel.isBold,
+                comment = "Uses bold fonts for certain language keywords",
+                actionListener = { _, component ->
+                  themeSettingsModel.isBold = component.isSelected
+                }
+            )
+          }
+        }
+        row {
+          cell {
+            fileIcon()
+            checkBox(
+                "Italic Characters",
+                themeSettingsModel.isItalic,
+                comment = "Uses italic font for language keywords and comments",
+                actionListener = { _, component ->
+                  themeSettingsModel.isItalic = component.isSelected
+                }
+            )
+          }
+        }
+        row {
+          cell {
+            psiIcon()
+            checkBox(
+                "Vivid Pallette",
+                themeSettingsModel.isVivid,
+                comment = "Uses the One-Dark vivid color pallette",
+                actionListener = { _, component ->
+                  themeSettingsModel.isVivid = component.isSelected
+                }
+            )
+          }
+        }
+      }
+      titledRow("Miscellaneous Items") {
+        row {
+          cell {
+            button("View Issues") {
+              browse(ISSUES_URI)
+            }
+            button("View Changelog") {
+              browse(CHANGELOG_URI)
+            }
+            button("Marketplace Homepage") {
+              browse(MARKETPLACE_URI)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -99,7 +99,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
             checkBox(
               "Vivid Palette",
               themeSettingsModel.isVivid,
-              comment = "Uses the One-Dark vivid color pallette",
+              comment = "Uses the One Dark vivid color palette",
               actionListener = { _, component ->
                 themeSettingsModel.isVivid = component.isSelected
               }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -21,7 +21,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
   companion object {
     const val THEME_SETTINGS_DISPLAY_NAME = "One Dark Theme"
     private const val REPOSITORY = "https://github.com/one-dark/jetbrains-one-dark-theme"
-    private val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md")
+    private val CHANGELOG_URI = URI("$REPOSITORY/blob/master/CHANGELOG.md#changelog")
     private val ISSUES_URI = URI("$REPOSITORY/issues")
     private val MARKETPLACE_URI = URI("https://plugins.jetbrains.com/plugin/11938-one-dark-theme")
   }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,9 @@
     <depends>com.intellij.modules.lang</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>
+        <applicationConfigurable id="oneDarkConfig" displayName="One Dark Settings" groupId="appearance"
+                                 instance="com.markskelton.settings.ThemeSettingsUI" />
         <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
         <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>
         <themeProvider id="4b6007f7-b596-4ee2-96f9-968d3d3eb392" path="/themes/one_dark_vivid.theme.json"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,8 +12,5 @@
                                  instance="com.markskelton.settings.ThemeSettingsUI" />
         <postStartupActivity implementation="com.markskelton.OneDarkTheme" />
         <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
-        <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>
-        <themeProvider id="4b6007f7-b596-4ee2-96f9-968d3d3eb392" path="/themes/one_dark_vivid.theme.json"/>
-        <themeProvider id="4f556d32-83cb-4b8b-9932-c4eccc4ce3af" path="/themes/one_dark_vivid_italic.theme.json"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>
-        <applicationConfigurable id="oneDarkConfig" displayName="One Dark Settings" groupId="appearance"
+        <applicationConfigurable groupId="appearance"
                                  instance="com.markskelton.settings.ThemeSettingsUI" />
         <postStartupActivity implementation="com.markskelton.OneDarkTheme" />
         <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
         <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>
         <applicationConfigurable id="oneDarkConfig" displayName="One Dark Settings" groupId="appearance"
                                  instance="com.markskelton.settings.ThemeSettingsUI" />
+        <postStartupActivity implementation="com.markskelton.OneDarkTheme" />
         <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
         <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>
         <themeProvider id="4b6007f7-b596-4ee2-96f9-968d3d3eb392" path="/themes/one_dark_vivid.theme.json"/>

--- a/src/main/resources/templates/normal.palette.json
+++ b/src/main/resources/templates/normal.palette.json
@@ -1,0 +1,12 @@
+{
+  "chalky": "#e5c07b",
+  "coral": "#e06c75",
+  "dark": "#5c6370",
+  "error": "#f44747",
+  "fountainBlue": "#56b6c2",
+  "green": "#98c379",
+  "lightWhite": "#abb2bf",
+  "malibu": "#61afef",
+  "purple": "#c678dd",
+  "whiskey": "#d19a66"
+}

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -57,6 +57,7 @@
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="APACHE_CONFIG.IDENTIFIER">
@@ -97,18 +98,20 @@
     <option name="BASH.HERE_DOC_END">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="BASH.HERE_DOC_START">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_OPERATION_SIGN" name="BASH.REDIRECTION"/>
     <option name="BASH.SHEBANG">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always$italic:theme%"/>
       </value>
     </option>
     <option name="BLADE_DIRECTIVE">
@@ -215,6 +218,7 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="59626f"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
@@ -225,7 +229,7 @@
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
@@ -236,7 +240,7 @@
     <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
@@ -263,7 +267,7 @@
     <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$green$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
@@ -274,7 +278,7 @@
     <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
@@ -295,7 +299,7 @@
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
@@ -321,7 +325,7 @@
     <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
@@ -357,11 +361,13 @@
     <option name="CSS.IMPORTANT">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
@@ -386,6 +392,7 @@
       <value>
         <option name="EFFECT_COLOR" value="$whiskey$"/>
         <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
         <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
@@ -399,6 +406,7 @@
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -445,12 +453,13 @@
     <option name="Clojure Line comment">
       <value>
         <option name="FOREGROUND" value="59626f"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="Clojure Literal">
       <value>
         <option name="FOREGROUND" value="fda5ff"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="Clojure Numbers">
@@ -501,19 +510,19 @@
     <option name="DEBUGGER_INLINED_VALUES">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="DEBUGGER_INLINED_VALUES_EXECUTION_LINE">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="DEBUGGER_INLINED_VALUES_MODIFIED">
       <value>
         <option name="FOREGROUND" value="ff8c00"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="DEFAULT_ATTRIBUTE">
@@ -524,6 +533,7 @@
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DEFAULT_CLASS_NAME">
@@ -547,6 +557,7 @@
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -600,21 +611,24 @@
     <option name="DEFAULT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DEFAULT_LABEL">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
@@ -705,6 +719,7 @@
     <option name="DJANGO_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="DJANGO_TAG_START_END">
@@ -757,7 +772,7 @@
     <option name="FIRST SYMBOL IN LIST">
       <value>
         <option name="FOREGROUND" value="df6a73"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -792,6 +807,7 @@
     <option name="GO_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="GO_BUILTIN_CONSTANT">
@@ -833,11 +849,13 @@
     <option name="GO_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="GO_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="GO_LOCAL_FUNCTION">
@@ -873,11 +891,12 @@
     <option name="HAML_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="HAML_FILTER">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="HAML_FILTER_CONTENT"/>
@@ -998,13 +1017,14 @@
     </option>
     <option name="JADE_FILTER_NAME">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK"/>
     <option name="JADE_STATEMENTS">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="JADE_TAG_CLASS">
@@ -1020,6 +1040,7 @@
     <option name="JAVA_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -1078,7 +1099,7 @@
     <option name="KOTLIN_ABSTRACT_CLASS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option baseAttributes="ANNOTATION_NAME_ATTRIBUTES" name="KOTLIN_ANNOTATION"/>
@@ -1093,13 +1114,13 @@
     <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="KOTLIN_ENUM_ENTRY">
@@ -1112,12 +1133,12 @@
     </option>
     <option name="KOTLIN_LABEL">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="KOTLIN_MUTABLE_VARIABLE">
       <value>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="KOTLIN_NAMED_ARGUMENT">
@@ -1138,7 +1159,7 @@
     <option name="KOTLIN_TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="KOTLIN_TYPE_PARAMETER">
@@ -1257,7 +1278,7 @@
     </option>
     <option name="MARKDOWN_BOLD">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="MARKDOWN_CODE_SPAN">
@@ -1302,12 +1323,13 @@
     </option>
     <option name="MARKDOWN_ITALIC">
       <value>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="MARKDOWN_LINK_TITLE">
       <value>
         <option name="FOREGROUND" value="$green$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="MARKDOWN_TABLE_SEPARATOR">
@@ -1374,12 +1396,13 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="OC.LABEL">
       <value>
         <option name="FOREGROUND" value="$lightWhite$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="OC.MACRONAME">
@@ -1443,7 +1466,7 @@
     <option name="PHP_ALIAS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1529,6 +1552,7 @@
     <option name="PY.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="PY.KEYWORD_ARGUMENT">
@@ -1549,6 +1573,7 @@
     <option name="PY.SELF_PARAMETER">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="PY.STRING">
@@ -1694,6 +1719,7 @@
     <option name="RUBY_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="RUBY_CONSTANT">
@@ -1826,7 +1852,7 @@
     </option>
     <option name="ReSharper.IL_TARGET_CODE_LABEL">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="ReSharper.IL_VIEWER_SYNCHRONIZATION">
@@ -1876,6 +1902,7 @@
     <option name="SLIM_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="SLIM_DOCTYPE_KWD">
@@ -1885,7 +1912,7 @@
     </option>
     <option name="SLIM_FILTER">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="SLIM_ID">
@@ -1956,7 +1983,7 @@
     <option name="SWIFT_SHEBANG_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always$italic:theme%"/>
       </value>
     </option>
     <option baseAttributes="STATIC_METHOD_ATTRIBUTES" name="Static method access"/>
@@ -1986,6 +2013,7 @@
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ff8c00"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="TS.MODULE_NAME">
@@ -2080,6 +2108,7 @@
     <option name="XPATH.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
@@ -2130,7 +2159,7 @@
     </option>
     <option name="com.plan9.LABEL">
       <value>
-        <option name="FONT_TYPE" value="1"/>
+        <option name="FONT_TYPE" value="%bold:always%"/>
       </value>
     </option>
     <option name="com.plan9.PSEUDO_INSTRUCTION">
@@ -2156,6 +2185,7 @@
     <option name="org.rust.LIFETIME">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="FONT_TYPE" value="%italic:theme%"/>
       </value>
     </option>
     <option name="org.rust.MACRO">
@@ -2180,7 +2210,7 @@
     <option name="org.rust.TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="2"/>
+        <option name="FONT_TYPE" value="%italic:always%"/>
       </value>
     </option>
     <option name="org.rust.TYPE_PARAMETER">

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -1,0 +1,2205 @@
+<scheme name="One Dark" parent_scheme="Darcula" version="142">
+  <colors>
+    <option name="ADDED_LINES_COLOR" value="$green$"/>
+    <option name="ANNOTATIONS_COLOR" value="a0a7b4"/>
+    <option name="CARET_COLOR" value="528bff"/>
+    <option name="CARET_ROW_COLOR" value="2c313c"/>
+    <option name="CONSOLE_BACKGROUND_KEY" value=""/>
+    <option name="DELETED_LINES_COLOR" value="$coral$"/>
+    <option name="DIAGRAM_ANNOTATION_EDGE" value="$chalky$"/>
+    <option name="DIAGRAM_DEFAULT_EDGE" value="a0a7b4"/>
+    <option name="DIAGRAM_GENERALIZATION_EDGE" value="$malibu$"/>
+    <option name="DIAGRAM_INNER_EDGE" value="$coral$"/>
+    <option name="DIAGRAM_NODE_BACKGROUND" value="323844"/>
+    <option name="DIAGRAM_NODE_HEADER" value="414855"/>
+    <option name="DIAGRAM_NOTE_BACKGROUND" value="414855"/>
+    <option name="DIAGRAM_NOTE_BORDER" value="$dark$"/>
+    <option name="DIAGRAM_REALIZATION_EDGE" value="$green$"/>
+    <option name="DIFF_SEPARATORS_BACKGROUND" value="21252b"/>
+    <option name="DOCUMENTATION_COLOR" value="3d424b"/>
+    <option name="ERROR_HINT" value="781732"/>
+    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="4f575f"/>
+    <option name="FOLDED_TEXT_BORDER_COLOR" value=""/>
+    <option name="GUTTER_BACKGROUND" value="282c34"/>
+    <option name="HTML_TAG_TREE_LEVEL0" value="$error$"/>
+    <option name="HTML_TAG_TREE_LEVEL1" value="$chalky$"/>
+    <option name="HTML_TAG_TREE_LEVEL2" value="$green$"/>
+    <option name="HTML_TAG_TREE_LEVEL3" value="$fountainBlue$"/>
+    <option name="HTML_TAG_TREE_LEVEL4" value="$malibu$"/>
+    <option name="HTML_TAG_TREE_LEVEL5" value="$purple$"/>
+    <option name="INDENT_GUIDE" value="3b4048"/>
+    <option name="INFORMATION_HINT" value="3d424b"/>
+    <option name="LINE_NUMBERS_COLOR" value="495162"/>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="737984"/>
+    <option name="METHOD_SEPARATORS_COLOR" value="3b4048"/>
+    <option name="MODIFIED_LINES_COLOR" value="$whiskey$"/>
+    <option name="QUESTION_HINT" value="2e4280"/>
+    <option name="RECENT_LOCATIONS_SELECTION" value="3d424b"/>
+    <option name="RIGHT_MARGIN_COLOR" value="606368"/>
+    <option name="SELECTED_INDENT_GUIDE" value="606368"/>
+    <option name="SELECTED_TEARLINE_COLOR" value="6b6e73"/>
+    <option name="SELECTION_BACKGROUND" value="404859"/>
+    <option name="SEPARATOR_BELOW_COLOR" value=""/>
+    <option name="TEARLINE_COLOR" value="4f575f"/>
+    <option name="VCS_ANNOTATIONS_COLOR_1" value="335027"/>
+    <option name="VCS_ANNOTATIONS_COLOR_2" value="3e443c"/>
+    <option name="VCS_ANNOTATIONS_COLOR_5" value="46333c"/>
+    <option name="VISUAL_INDENT_GUIDE" value="3b4048"/>
+    <option name="WHITESPACES" value="4b575f"/>
+    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="$dark$"/>
+  </colors>
+  <attributes>
+    <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="ANNOTATION_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="APACHE_CONFIG.IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="9b3636"/>
+      </value>
+    </option>
+    <option name="BASH.BINARY_DATA">
+      <value>
+        <option name="FOREGROUND" value=""/>
+      </value>
+    </option>
+    <option name="BASH.CONDITIONAL">
+      <value>
+        <option name="FOREGROUND" value=""/>
+      </value>
+    </option>
+    <option name="BASH.EXTERNAL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="BASH.FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="BASH.HERE_DOC">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="BASH.HERE_DOC_END">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="BASH.HERE_DOC_START">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_OPERATION_SIGN" name="BASH.REDIRECTION"/>
+    <option name="BASH.SHEBANG">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="BLADE_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="BOOKMARKS_ATTRIBUTES">
+      <value/>
+    </option>
+    <option name="BREADCRUMBS_CURRENT">
+      <value>
+        <option name="BACKGROUND" value="353a46"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="BREADCRUMBS_DEFAULT">
+      <value>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="BREADCRUMBS_HOVERED">
+      <value>
+        <option name="BACKGROUND" value="444b5a"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="BREADCRUMBS_INACTIVE">
+      <value>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="BREAKPOINT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="743d3d"/>
+      </value>
+    </option>
+    <option name="BUILDOUT.KEY">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BOOLEAN">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION_BINDING">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option baseAttributes="JS.GLOBAL_VARIABLE" name="COFFEESCRIPT.GLOBAL_VARIABLE"/>
+    <option name="COFFEESCRIPT.HEREGEX_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREGEX_ID">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.STRING">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="CONDITIONALLY_NOT_COMPILED">
+      <value>
+        <option name="FOREGROUND" value="59626f"/>
+      </value>
+    </option>
+    <option name="CONSOLE_BLACK_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="000000"/>
+      </value>
+    </option>
+    <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_BLUE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_CYAN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_DARKGRAY_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="464c55"/>
+      </value>
+    </option>
+    <option name="CONSOLE_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_GRAY_OUTPUT">
+      <value>
+        <option name="ERROR_STRIPE_COLOR" value="21252b"/>
+        <option name="FOREGROUND" value="646a73"/>
+      </value>
+    </option>
+    <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_GREEN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_MAGENTA_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_NORMAL_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_RANGE_TO_EXECUTE">
+      <value>
+        <option name="EFFECT_COLOR" value="$dark$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_RED_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_RED_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_SYSTEM_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="e7f2ff"/>
+      </value>
+    </option>
+    <option name="CONSOLE_USER_INPUT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_WHITE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CONSOLE_YELLOW_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_CALL_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="CSS.COLOR">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="CSS.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="CSS.HASH">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="CSS.IDENT">
+      <value>
+        <option name="FOREGROUND" value="d39a63"/>
+      </value>
+    </option>
+    <option name="CSS.IMPORTANT">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="CSS.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="CSS.PROPERTY_NAME">
+      <value/>
+    </option>
+    <option name="CSS.PROPERTY_VALUE">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="CSS.PSEUDO">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="CSS.TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="CSS.URL">
+      <value>
+        <option name="EFFECT_COLOR" value="$whiskey$"/>
+        <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="EFFECT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CTRL_CLICKABLE">
+      <value>
+        <option name="EFFECT_COLOR" value="$malibu$"/>
+        <option name="FOREGROUND" value="$malibu$"/>
+        <option name="EFFECT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="CUSTOM_STRING_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option baseAttributes="CLASS_NAME_ATTRIBUTES" name="Class"/>
+    <option name="Clojure Atom">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="Clojure Character">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="Clojure Keyword">
+      <value>
+        <option name="FOREGROUND" value="df6a73"/>
+      </value>
+    </option>
+    <option name="Clojure Line comment">
+      <value>
+        <option name="FOREGROUND" value="59626f"/>
+      </value>
+    </option>
+    <option name="Clojure Literal">
+      <value>
+        <option name="FOREGROUND" value="fda5ff"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="Clojure Numbers">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="Clojure Strings">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="DART_ENUM_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DART_INSTANCE_GETTER_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DART_INSTANCE_SETTER_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DART_LOCAL_FUNCTION_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DART_LOCAL_FUNCTION_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DART_STATIC_GETTER_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DART_STATIC_SETTER_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DEBUGGER_INLINED_VALUES">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="DEBUGGER_INLINED_VALUES_EXECUTION_LINE">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="DEBUGGER_INLINED_VALUES_MODIFIED">
+      <value>
+        <option name="FOREGROUND" value="ff8c00"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_COMMA">
+      <value/>
+    </option>
+    <option name="DEFAULT_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_IDENTIFIER">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_INTERFACE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_LABEL">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_METADATA">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="DEFAULT_REASSIGNED_LOCAL_VARIABLE"/>
+    <option name="DEFAULT_REASSIGNED_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_SEMICOLON">
+      <value/>
+    </option>
+    <option name="DEFAULT_STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_STATIC_METHOD">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="DEFAULT_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="DELETED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="692424"/>
+      </value>
+    </option>
+    <option name="DEPRECATED_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$lightWhite$"/>
+        <option name="EFFECT_TYPE" value="3"/>
+      </value>
+    </option>
+    <option name="DIFF_CONFLICT">
+      <value>
+        <option name="BACKGROUND" value="913a3a"/>
+        <option name="ERROR_STRIPE_COLOR" value="$coral$"/>
+      </value>
+    </option>
+    <option name="DIFF_DELETED">
+      <value>
+        <option name="BACKGROUND" value="353c46"/>
+        <option name="ERROR_STRIPE_COLOR" value="$dark$"/>
+      </value>
+    </option>
+    <option name="DIFF_INSERTED">
+      <value>
+        <option name="BACKGROUND" value="2d4134"/>
+        <option name="ERROR_STRIPE_COLOR" value="$green$"/>
+      </value>
+    </option>
+    <option name="DIFF_MODIFIED">
+      <value>
+        <option name="BACKGROUND" value="2c4957"/>
+        <option name="ERROR_STRIPE_COLOR" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DJANGO_FILTER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="DJANGO_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="DJANGO_TAG_START_END">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="DOCKER_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="DUPLICATE_FROM_SERVER">
+      <value/>
+    </option>
+    <option name="EDITORCONFIG_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="EL.BOUNDS">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="ENUM_CONST">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="ERRORS_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="ERROR_STRIPE_COLOR" value="$error$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="EVALUATED_EXPRESSION_ATTRIBUTES">
+      <value/>
+    </option>
+    <option name="EVALUATED_EXPRESSION_EXECUTION_LINE_ATTRIBUTES">
+      <value/>
+    </option>
+    <option name="EXECUTIONPOINT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="c7c7ff"/>
+        <option name="FOREGROUND" value="000000"/>
+      </value>
+    </option>
+    <option name="FIRST SYMBOL IN LIST">
+      <value>
+        <option name="FOREGROUND" value="df6a73"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="FOLDED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="313741"/>
+        <option name="FOREGROUND" value="878e9b"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$purple$"/>
+        <option name="FOREGROUND" value="$purple$"/>
+        <option name="EFFECT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+      <value>
+        <option name="EFFECT_COLOR" value="ff8c00"/>
+        <option name="ERROR_STRIPE_COLOR" value="ff8c00"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="GHERKIN_REGEXP_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="GHERKIN_TABLE_PIPE">
+      <value/>
+    </option>
+    <option name="GO_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="GO_BUILTIN_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="GO_BUILTIN_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="GO_BUILTIN_TYPE">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="GO_BUILTIN_TYPE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_GLOBAL_VARIABLE" name="GO_BUILTIN_VARIABLE"/>
+    <option name="GO_EXPORTED_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="GO_EXPORTED_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="GO_FUNCTION_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="GO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="GO_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="GO_METHOD_RECEIVER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="GO_PACKAGE"/>
+    <option name="GO_TYPE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="GQL_ID">
+      <value/>
+    </option>
+    <option baseAttributes="METHOD_DECLARATION_ATTRIBUTES" name="Groovy method declaration"/>
+    <option name="HAML_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="HAML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="HAML_FILTER">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="HAML_FILTER_CONTENT"/>
+    <option name="HAML_ID">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="HAML_RUBY_CODE">
+      <value/>
+    </option>
+    <option name="HAML_STRING_INTERPOLATED">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="HAML_TAG">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="HAML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="HAML_TEXT">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="HAML_XHTML"/>
+    <option name="HTML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="HTML_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="HTML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_TAG" name="HTML_TAG"/>
+    <option name="HTML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$purple$"/>
+        <option name="FOREGROUND" value="$purple$"/>
+        <option name="EFFECT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="353940"/>
+      </value>
+    </option>
+    <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+      <value/>
+    </option>
+    <option name="INACTIVE_HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$lightWhite$"/>
+        <option name="EFFECT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="INFO_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$chalky$"/>
+        <option name="ERROR_STRIPE_COLOR" value="$chalky$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="INI.SECTION">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="INJECTED_LANGUAGE_FRAGMENT">
+      <value/>
+    </option>
+    <option name="INLINE_PARAMETER_HINT">
+      <value>
+        <option name="BACKGROUND" value="414855"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_CURRENT">
+      <value>
+        <option name="BACKGROUND" value="48709b"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="BACKGROUND" value="$dark$"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="IVAR">
+      <value>
+        <option name="FOREGROUND" value="df6a73"/>
+      </value>
+    </option>
+    <option name="JADE_FILE_PATH">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="JADE_FILTER_NAME">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK"/>
+    <option name="JADE_STATEMENTS">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="JADE_TAG_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="JADE_TAG_ID">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="JAVA_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="JAVA_STRING">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="JAVA_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="JS.ATTRIBUTE">
+      <value>
+        <option name="BACKGROUND" value="423535"/>
+      </value>
+    </option>
+    <option name="JS.GLOBAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_GLOBAL_VARIABLE" name="JS.GLOBAL_VARIABLE"/>
+    <option baseAttributes="DEFAULT_INSTANCE_METHOD" name="JS.INSTANCE_MEMBER_FUNCTION"/>
+    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="JS.LOCAL_VARIABLE"/>
+    <option name="JS.MODULE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="JS.REGEXP">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="JSON.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="JSON.PROPERTY_KEY">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="JSP_DIRECTIVE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="JUPYTER_SELECTED_CELL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="KOTLIN_ABSTRACT_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option baseAttributes="ANNOTATION_NAME_ATTRIBUTES" name="KOTLIN_ANNOTATION"/>
+    <option name="KOTLIN_BACKING_FIELD_VARIABLE">
+      <value/>
+    </option>
+    <option name="KOTLIN_CLOSURE_DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="KOTLIN_ENUM_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="KOTLIN_FUNCTION_LITERAL_BRACES_AND_ARROW">
+      <value/>
+    </option>
+    <option name="KOTLIN_LABEL">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="KOTLIN_MUTABLE_VARIABLE">
+      <value>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="KOTLIN_NAMED_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_STATIC_METHOD" name="KOTLIN_PACKAGE_FUNCTION_CALL"/>
+    <option name="KOTLIN_SMART_CAST_RECEIVER">
+      <value/>
+    </option>
+    <option name="KOTLIN_SMART_CAST_VALUE">
+      <value/>
+    </option>
+    <option name="KOTLIN_SMART_CONSTANT">
+      <value/>
+    </option>
+    <option name="KOTLIN_TYPE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="KOTLIN_TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="KOTLIN_VARIABLE_AS_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="KOTLIN_VARIABLE_AS_FUNCTION_LIKE">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="LABEL">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LESS_VARIABLE">
+      <value/>
+    </option>
+    <option name="LINE_FULL_COVERAGE">
+      <value>
+        <option name="FOREGROUND" value="354a3d"/>
+      </value>
+    </option>
+    <option name="LINE_NONE_COVERAGE">
+      <value>
+        <option name="FOREGROUND" value="46333c"/>
+      </value>
+    </option>
+    <option name="LINE_PARTIAL_COVERAGE">
+      <value>
+        <option name="FOREGROUND" value="2c4957"/>
+      </value>
+    </option>
+    <option name="LIVE_TEMPLATE_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+      </value>
+    </option>
+    <option name="LOCALE.MSGCTXT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LOCALE.MSGID_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LOCALE.MSGID_PLURAL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LOCALE.MSGSTR_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LOCALE.MSGSTR_PLURAL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="LOG_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="LOG_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="LOG_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="LOG_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="LOG_WARNING_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="List/map to object conversion">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="MACRONAME">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="MAGIC_MEMBER_ACCESS">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="MAKO.SUBSTITUTION"/>
+    <option name="MAKO.TAG">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_BOLD">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_CODE_SPAN">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_CODE_SPAN_MARKER">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_1">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_2">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_3">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_4">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_5">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_6">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_ITALIC">
+      <value>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_LINK_TITLE">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="MARKDOWN_TABLE_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="MARKED_FOR_REMOVAL_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="EFFECT_TYPE" value="3"/>
+      </value>
+    </option>
+    <option name="MATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="515a6b"/>
+      </value>
+    </option>
+    <option name="MESSAGE_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="NG.BANANA_BINDING_ATTR_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="NG.EVENT_BINDING_ATTR_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="NG.PROPERTY_BINDING_ATTR_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="NG.TEMPLATE_BINDINGS_ATTR_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="NOT_USED_ELEMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="7f8591"/>
+      </value>
+    </option>
+    <option name="OC.CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="OC.CONDITIONALLY_NOT_COMPILED">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="OC.CPP_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="OC.DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="OC.LABEL">
+      <value>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="OC.MACRONAME">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="OC.MACRO_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="OC.MESSAGE_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="OC.METHOD_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="OC.OVERLOADED_OPERATOR">
+      <value/>
+    </option>
+    <option name="OC.PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="OC.PROPERTY_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="OC.PROTOCOL_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="OC.STRUCT_FIELD">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="OC.STRUCT_LIKE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="OC.TYPEDEF">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="OC_FORMAT_TOKEN">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="PHP_ALIAS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="PHP_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="PHP_EXEC_COMMAND_ID">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="PHP_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="PHP_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="PHP_SCRIPTING_BACKGROUND">
+      <value/>
+    </option>
+    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="PHP_VAR"/>
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="PROPERTIES.KEY">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_OPERATION_SIGN" name="PROPERTIES.KEY_VALUE_SEPARATOR"/>
+    <option name="PROPERTIES.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="PROTOCOL_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="PUPPET_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="PUPPET_HEREDOC_TAGS">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="PUPPET_REGEX">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="PUPPET_VARIABLE">
+      <value/>
+    </option>
+    <option name="PY.ANNOTATION">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="PY.BUILTIN_NAME">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="PY.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="PY.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="PY.STRING">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="PY.STRING.B">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="RDOC_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="RDOC_EMAIL">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="RDOC_HEADINGS">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="RDOC_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="RDOC_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="RDOC_URL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="REGEXP.BRACES">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="REGEXP.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="REGEXP.CHAR_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="REGEXP.ESC_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="REGEXP.META">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="REGEXP.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="REGEXP.QUOTE_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="REGEXP.REDUNDANT_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="REST.EXPLICIT">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="REST.FIELD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="REST.FIXED">
+      <value>
+        <option name="BACKGROUND" value="3d424b"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="REST.INLINE"/>
+    <option name="REST.INTERPRETED">
+      <value>
+        <option name="BACKGROUND" value="3c4b33"/>
+      </value>
+    </option>
+    <option name="REST.SECTION.HEADER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option baseAttributes="HTML_COMMENT" name="RHTML_COMMENT_ID"/>
+    <option name="RHTML_EXPRESSION_END_ID">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="RHTML_EXPRESSION_START_ID">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="RHTML_OMIT_NEW_LINE_ID">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+      <value/>
+    </option>
+    <option name="RHTML_SCRIPTLET_END_ID">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="RHTML_SCRIPTLET_START_ID">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="RUBY_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="9b3636"/>
+      </value>
+    </option>
+    <option name="RUBY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="RUBY_ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="RUBY_EXPR_IN_STRING">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_GLOBAL_VARIABLE" name="RUBY_GVAR"/>
+    <option name="RUBY_HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="RUBY_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="RUBY_LINE_CONTINUATION">
+      <value/>
+    </option>
+    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="RUBY_LOCAL_VAR_ID"/>
+    <option baseAttributes="DEFAULT_INSTANCE_METHOD" name="RUBY_METHOD_NAME"/>
+    <option name="RUBY_NTH_REF">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="RUBY_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_STATIC_METHOD" name="RUBY_PARAMDEF_CALL"/>
+    <option name="RUBY_PARAMETER_ID">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="RUBY_REGEXP">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_STATIC_METHOD" name="RUBY_SPECIFIC_CALL"/>
+    <option name="RUBY_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="RUBY_WORDS">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="RUNTIME_ERROR">
+      <value>
+        <option name="EFFECT_COLOR" value="ff8c00"/>
+        <option name="ERROR_STRIPE_COLOR" value="$error$"/>
+        <option name="EFFECT_TYPE" value="5"/>
+      </value>
+    </option>
+    <option name="ReSharper.ASP_NET_MVC_ACTION">
+      <value/>
+    </option>
+    <option name="ReSharper.ASP_NET_MVC_AREA">
+      <value/>
+    </option>
+    <option name="ReSharper.ASP_NET_MVC_CONTROLLER">
+      <value/>
+    </option>
+    <option name="ReSharper.ASP_NET_MVC_VIEW">
+      <value/>
+    </option>
+    <option name="ReSharper.ASP_NET_MVC_VIEW_COMPONENT">
+      <value/>
+    </option>
+    <option name="ReSharper.ASP_NET_RUN_AT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="ReSharper.BRACE_OUTLINE">
+      <value>
+        <option name="EFFECT_COLOR" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="ReSharper.FORMAT_STRING_ITEM">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="ReSharper.FORMAT_STRING_ITEM_2">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="ReSharper.HINT">
+      <value>
+        <option name="EFFECT_COLOR" value="$malibu$"/>
+        <option name="EFFECT_TYPE" value="5"/>
+      </value>
+    </option>
+    <option name="ReSharper.IL_INSTRUCTION">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="ReSharper.IL_TARGET_CODE_LABEL">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="ReSharper.IL_VIEWER_SYNCHRONIZATION">
+      <value/>
+    </option>
+    <option name="ReSharper.MATCHED_FORMAT_STRING_ITEM">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="ReSharper.OUTLINED_ENTITY">
+      <value>
+        <option name="EFFECT_COLOR" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="ReSharper.STRING_ESCAPE_CHARACTER_2">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option baseAttributes="CSS.COMMENT" name="SASS_COMMENT"/>
+    <option name="SASS_MIXIN">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="SASS_VARIABLE">
+      <value/>
+    </option>
+    <option name="SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="42557b"/>
+        <option name="EFFECT_COLOR" value="457dff"/>
+      </value>
+    </option>
+    <option name="SLIM_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="f2777a"/>
+        <option name="FOREGROUND" value="272b33"/>
+      </value>
+    </option>
+    <option name="SLIM_CLASS">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="SLIM_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+      </value>
+    </option>
+    <option name="SLIM_DOCTYPE_KWD">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="SLIM_FILTER">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="SLIM_ID">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="SLIM_INTERPOLATION">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_PARENTHS" name="SLIM_PARENTHS"/>
+    <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="SLIM_RUBY_CODE"/>
+    <option name="SLIM_STATIC_CONTENT">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="SLIM_STRING_INTERPOLATED">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="SLIM_TAG">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="SLIM_TAG_ATTR_KEY">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="SQL_COLUMN" name="SQL_OUTER_QUERY_COLUMN"/>
+    <option baseAttributes="DEFAULT_PREDEFINED_SYMBOL" name="SQL_SYNTHETIC_ENTITY"/>
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_STATIC_METHOD" name="STATIC_METHOD_ATTRIBUTES"/>
+    <option name="STATIC_METHOD_IMPORTED_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="STYLUS_VARIABLE">
+      <value/>
+    </option>
+    <option name="SUGGESTION">
+      <value>
+        <option name="EFFECT_COLOR" value="$malibu$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="SWIFT_ATTRIBUTE_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="SWIFT_EXTERNAL_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="SWIFT_SHEBANG_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="$dark$"/>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option baseAttributes="STATIC_METHOD_ATTRIBUTES" name="Static method access"/>
+    <option name="Static property reference ID">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="TEXT">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="42557b"/>
+        <option name="EFFECT_COLOR" value="457dff"/>
+        <option name="ERROR_STRIPE_COLOR" value="457dff"/>
+      </value>
+    </option>
+    <option name="TODO_DEFAULT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ff8c00"/>
+      </value>
+    </option>
+    <option name="TS.MODULE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="TS.TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="TYPEDEF">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="TYPO">
+      <value>
+        <option name="EFFECT_COLOR" value="$green$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="UNMATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="583535"/>
+      </value>
+    </option>
+    <option name="Unresolved reference access">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="WARNING_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="ff8c00"/>
+        <option name="ERROR_STRIPE_COLOR" value="ff8c00"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="353940"/>
+      </value>
+    </option>
+    <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="42557b"/>
+        <option name="EFFECT_COLOR" value="457dff"/>
+      </value>
+    </option>
+    <option name="WRONG_REFERENCES_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="$error$"/>
+        <option name="ERROR_STRIPE_COLOR" value="$error$"/>
+        <option name="EFFECT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="XML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="XML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="XML_NS_PREFIX">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="XML_PROLOGUE">
+      <value>
+        <option name="BACKGROUND" value="282c34"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_TAG" name="XML_TAG"/>
+    <option name="XML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="XPATH.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="XPATH.XPATH_NAME">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="XPATH.XPATH_VARIABLE"/>
+    <option name="YAML_ANCHOR">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="YAML_SCALAR_KEY">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="YAML_SCALAR_LIST">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="YAML_SCALAR_VALUE">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="YAML_TEXT">
+      <value>
+        <option name="FOREGROUND" value="$green$"/>
+      </value>
+    </option>
+    <option name="com.plan9.IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="com.plan9.INSTRUCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="com.plan9.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+      </value>
+    </option>
+    <option name="com.plan9.LABEL">
+      <value>
+        <option name="FONT_TYPE" value="1"/>
+      </value>
+    </option>
+    <option name="com.plan9.PSEUDO_INSTRUCTION">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="com.plan9.REGISTER">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="org.rust.DOC_LINK">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option name="org.rust.ENUM_VARIANT">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="org.rust.LIFETIME">
+      <value>
+        <option name="FOREGROUND" value="$fountainBlue$"/>
+      </value>
+    </option>
+    <option name="org.rust.MACRO">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="org.rust.MUT_BINDING"/>
+    <option name="org.rust.MUT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$"/>
+      </value>
+    </option>
+    <option name="org.rust.PRIMITIVE_TYPE">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="org.rust.Q_OPERATOR">
+      <value/>
+    </option>
+    <option name="org.rust.TYPE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
+    <option name="org.rust.TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="org.rust.UNSAFE_CODE">
+      <value/>
+    </option>
+    <option name="osmorc.attributeName">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+    <option name="osmorc.directiveName">
+      <value>
+        <option name="FOREGROUND" value="$coral$"/>
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -1,4 +1,7 @@
 <scheme name="One Dark" parent_scheme="Darcula" version="142">
+  <metaInfo>
+    <property name="oneDarkScheme">runtimeGenerated</property>
+  </metaInfo>
   <colors>
     <option name="ADDED_LINES_COLOR" value="$green$"/>
     <option name="ANNOTATIONS_COLOR" value="a0a7b4"/>

--- a/src/main/resources/templates/vivid.palette.json
+++ b/src/main/resources/templates/vivid.palette.json
@@ -1,0 +1,12 @@
+{
+  "chalky": "#e5c07b",
+  "coral": "#ef596f",
+  "dark": "#5c6370",
+  "error": "#f44747",
+  "fountainBlue": "#2bbac5",
+  "green": "#89ca78",
+  "lightWhite": "#bbbbbb",
+  "malibu": "#61afef",
+  "purple": "#d55fde",
+  "whiskey": "#d19a66"
+}


### PR DESCRIPTION
## Motivation

Fixes #139 

## High Level Details

The plugin utilizes the pre-existing `one_dark.theme.json` to provide the One-Dark look and feel, however it now generates an xml editor scheme definition. That way I could utilize the pre-existing SDK for applying color themes. The generated xml file is stored in `<config-directory>/oneDarkAssets/one-dark-[random uuid].xml` (see comments on why the uuid is needed :). [Here is a link to where the config directories are for all systems](https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.162494140.1090292780.1590344453-1743808472.1573820804#config-directory)
The xml file is generated from an xml template stored in classpath. 

The plugin still remains a dynamic plugin, so the users can update without restarting the IDE.

## Migration Strategy

I kept the legacy themes for the sole purpose of migrating the user to the new configuration. This way when they update, they will have nothing to do (provided they where using One Dark at time of update). If the themes where removed, I wouldn't know what was set by looking at the current set theme.

I also have things set up so that when the user chooses a variant theme, it will update the config and set the theme back to the default theme. I also set it up to prompt the user about the theme being deprecated and gave theme a link to the settings.

![Peek 2020-05-24 10-11](https://user-images.githubusercontent.com/15972415/82761795-bc80df00-9dc2-11ea-9d80-56b29a842370.gif)

I tested that the update is smooth for: Windows 10, MacOS, and Linux. I was able to replicate the JetBrains update process by utilizing my canary release channel. If you would like to test/observe the update behavior [you can temporarily add my Canary release channel, see the README.md for more details :)](https://github.com/Unthrottled/jetbrains-plugin-repository#canary)

## Extras!

- I added an update notification that gives the users an idea of what is new in the update.
- I wrote this in Kotlin because Kotlin is awesome. Plus it's built by JetBrains, so it works really well here!
  - I have a Kotlin Linter added as well. It runs as part of the build process. You can auto fix lint issues with `./gradlew ktlintFormat`
- Configurations are persisted in an XML format, you can find the file in `<config directory>/one_dark_config.xml`