### PR TITLE
Granular Font Settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,7 @@ configurations {
 
 
 intellij {
-  version '2020.1'
-  type 'IU'
+  version 'LATEST-EAP-SNAPSHOT'
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,7 @@ configurations {
 
 
 intellij {
-  version '2020.1'
-  type 'IU'
+  version 'LATEST-EAP-SNAPSHOT'   
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ configurations {
 
 
 intellij {
-  version 'LATEST-EAP-SNAPSHOT'
+  version '2020.1'
+  type 'IU'
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,9 @@ configurations {
 
 
 intellij {
-    version 'LATEST-EAP-SNAPSHOT'
-    alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
+  version '2020.1'
+  type 'IU'
+  alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 }
 
 compileKotlin {

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -149,7 +149,7 @@ object ThemeConstructor {
     fontSpecifications: List<String>,
     themeSettings: ThemeSettings
   ): Boolean =
-    matchesThemeSetting(fontSpecifications, "bold:") {
+    matchesThemeSetting(fontSpecifications, "bold") {
       val relevantGroupStyle = getRelevantGroupStyle(it, themeSettings)
       relevantGroupStyle == GroupStyling.BOLD ||
         relevantGroupStyle == GroupStyling.BOLD_ITALIC
@@ -166,7 +166,7 @@ object ThemeConstructor {
     fontSpecifications: List<String>,
     themeSettings: ThemeSettings
   ): Boolean =
-    matchesThemeSetting(fontSpecifications, "italic:") {
+    matchesThemeSetting(fontSpecifications, "italic") {
       val relevantGroupStyle = getRelevantGroupStyle(it, themeSettings)
       relevantGroupStyle == GroupStyling.ITALIC ||
         relevantGroupStyle == GroupStyling.BOLD_ITALIC
@@ -178,13 +178,11 @@ object ThemeConstructor {
     isCurrentThemeSetting: (group: Groups) -> Boolean
   ): Boolean =
     fontSpecifications.any {
-      it.startsWith(prefix) &&
-        (it.endsWith(":always") ||
-          (it.contains(":theme") &&
+      it.startsWith(prefix) ||
+          (it.startsWith("theme") &&
             isCurrentThemeSetting(
               it.substringAfter("^").toGroup()
             ))
-          )
     }
 
   private fun buildReplacement(replacementColor: String, value: String, end: Int) =

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -149,7 +149,9 @@ object ThemeConstructor {
     themeSettings: ThemeSettings
   ): Boolean =
     matchesThemeSetting(fontSpecifications, "bold:") {
-      themeSettings.isBold
+      // todo: revisit this
+//      themeSettings.isBold
+      false
     }
 
   private fun isEffectItalic(
@@ -157,7 +159,9 @@ object ThemeConstructor {
     themeSettings: ThemeSettings
   ): Boolean =
     matchesThemeSetting(fontSpecifications, "italic:") {
-      themeSettings.isItalic
+      // todo: revisit this
+//      themeSettings.isBold
+      false
     }
 
   private fun matchesThemeSetting(fontSpecifications: List<String>, prefix: String, isCurrentThemeSetting: () -> Boolean): Boolean =

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -9,8 +9,12 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.vfs.VfsUtil
 import com.markskelton.OneDarkThemeManager.ONE_DARK_ID
-import com.markskelton.settings.*
+import com.markskelton.settings.GroupStyling
+import com.markskelton.settings.Groups
 import com.markskelton.settings.Groups.*
+import com.markskelton.settings.ThemeSettings
+import com.markskelton.settings.toGroup
+import com.markskelton.settings.toGroupStyle
 import groovy.util.Node
 import groovy.util.XmlNodePrinter
 import groovy.util.XmlParser
@@ -25,7 +29,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
+import java.util.UUID
 import javax.swing.UIManager
 
 enum class ColorVariant {
@@ -155,13 +159,6 @@ object ThemeConstructor {
         relevantGroupStyle == GroupStyling.BOLD_ITALIC
     }
 
-  private fun getRelevantGroupStyle(it: Groups, themeSettings: ThemeSettings): GroupStyling =
-    when (it) {
-      ATTRIBUTES -> themeSettings.attributesStyle
-      COMMENTS -> themeSettings.commentStyle
-      KEYWORDS -> themeSettings.keywordStyle
-    }.toGroupStyle()
-
   private fun isEffectItalic(
     fontSpecifications: List<String>,
     themeSettings: ThemeSettings
@@ -172,6 +169,13 @@ object ThemeConstructor {
         relevantGroupStyle == GroupStyling.BOLD_ITALIC
     }
 
+  private fun getRelevantGroupStyle(it: Groups, themeSettings: ThemeSettings): GroupStyling =
+    when (it) {
+      ATTRIBUTES -> themeSettings.attributesStyle
+      COMMENTS -> themeSettings.commentStyle
+      KEYWORDS -> themeSettings.keywordStyle
+    }.toGroupStyle()
+
   private fun matchesThemeSetting(
     fontSpecifications: List<String>,
     prefix: String,
@@ -179,10 +183,10 @@ object ThemeConstructor {
   ): Boolean =
     fontSpecifications.any {
       it.startsWith(prefix) ||
-          (it.startsWith("theme") &&
-            isCurrentThemeSetting(
-              it.substringAfter("^").toGroup()
-            ))
+        (it.startsWith("theme") &&
+          isCurrentThemeSetting(
+            it.substringAfter("^").toGroup()
+          ))
     }
 
   private fun buildReplacement(replacementColor: String, value: String, end: Int) =

--- a/src/main/kotlin/com/markskelton/ThemeConstructor.kt
+++ b/src/main/kotlin/com/markskelton/ThemeConstructor.kt
@@ -9,11 +9,8 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.vfs.VfsUtil
 import com.markskelton.OneDarkThemeManager.ONE_DARK_ID
-import com.markskelton.settings.GroupStyling
-import com.markskelton.settings.Groups
+import com.markskelton.settings.*
 import com.markskelton.settings.Groups.*
-import com.markskelton.settings.ThemeSettings
-import com.markskelton.settings.toGroup
 import groovy.util.Node
 import groovy.util.XmlNodePrinter
 import groovy.util.XmlParser
@@ -154,16 +151,16 @@ object ThemeConstructor {
   ): Boolean =
     matchesThemeSetting(fontSpecifications, "bold:") {
       val relevantGroupStyle = getRelevantGroupStyle(it, themeSettings)
-      relevantGroupStyle == GroupStyling.BOLD.value ||
-        relevantGroupStyle == GroupStyling.BOLD_ITALIC.value
+      relevantGroupStyle == GroupStyling.BOLD ||
+        relevantGroupStyle == GroupStyling.BOLD_ITALIC
     }
 
-  private fun getRelevantGroupStyle(it: Groups, themeSettings: ThemeSettings): String =
+  private fun getRelevantGroupStyle(it: Groups, themeSettings: ThemeSettings): GroupStyling =
     when (it) {
       ATTRIBUTES -> themeSettings.attributesStyle
       COMMENTS -> themeSettings.commentStyle
       KEYWORDS -> themeSettings.keywordStyle
-    }
+    }.toGroupStyle()
 
   private fun isEffectItalic(
     fontSpecifications: List<String>,
@@ -171,8 +168,8 @@ object ThemeConstructor {
   ): Boolean =
     matchesThemeSetting(fontSpecifications, "italic:") {
       val relevantGroupStyle = getRelevantGroupStyle(it, themeSettings)
-      relevantGroupStyle == GroupStyling.ITALIC.value ||
-        relevantGroupStyle == GroupStyling.BOLD_ITALIC.value
+      relevantGroupStyle == GroupStyling.ITALIC ||
+        relevantGroupStyle == GroupStyling.BOLD_ITALIC
     }
 
   private fun matchesThemeSetting(
@@ -183,7 +180,7 @@ object ThemeConstructor {
     fontSpecifications.any {
       it.startsWith(prefix) &&
         (it.endsWith(":always") ||
-          (it.endsWith(":theme") &&
+          (it.contains(":theme") &&
             isCurrentThemeSetting(
               it.substringAfter("^").toGroup()
             ))

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -81,7 +81,7 @@ object LegacyMigration {
       }.toOptional()
 
   private fun applyItalicSettings() {
-    ThemeSettings.instance.attributesStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.attributesStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.commentStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.keywordStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.isVivid = false
@@ -95,7 +95,7 @@ object LegacyMigration {
   }
 
   private fun applyVividItalicSettings() {
-    ThemeSettings.instance.attributesStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.attributesStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.commentStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.keywordStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.isVivid = true

--- a/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/com/markskelton/legacy/LegacyMigration.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.RoamingType
 import com.markskelton.OneDarkThemeManager
 import com.markskelton.doOrElse
+import com.markskelton.settings.GroupStyling
 import com.markskelton.settings.THEME_CONFIG_TOPIC
 import com.markskelton.settings.ThemeSettings
 import com.markskelton.toOptional
@@ -80,17 +81,23 @@ object LegacyMigration {
       }.toOptional()
 
   private fun applyItalicSettings() {
-    ThemeSettings.instance.isItalic = true
+    ThemeSettings.instance.attributesStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.commentStyle = GroupStyling.ITALIC.value
+    ThemeSettings.instance.keywordStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.isVivid = false
   }
 
   private fun applyVividSettings() {
+    ThemeSettings.instance.attributesStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.commentStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.keywordStyle = GroupStyling.REGULAR.value
     ThemeSettings.instance.isVivid = true
-    ThemeSettings.instance.isItalic = false
   }
 
   private fun applyVividItalicSettings() {
-    ThemeSettings.instance.isItalic = true
+    ThemeSettings.instance.attributesStyle = GroupStyling.REGULAR.value
+    ThemeSettings.instance.commentStyle = GroupStyling.ITALIC.value
+    ThemeSettings.instance.keywordStyle = GroupStyling.ITALIC.value
     ThemeSettings.instance.isVivid = true
   }
 }

--- a/src/main/kotlin/com/markskelton/settings/GroupStyling.kt
+++ b/src/main/kotlin/com/markskelton/settings/GroupStyling.kt
@@ -1,0 +1,15 @@
+package com.markskelton.settings
+
+enum class GroupStyling(
+  val value: String
+) {
+  REGULAR("Regular"), ITALIC("Italic"), BOLD("Bold"), BOLD_ITALIC("Bold Italic")
+}
+
+private val styleMappings = GroupStyling.values()
+  .map { it.value to it }
+  .toMap()
+
+fun String.toGroupStyle(): GroupStyling = styleMappings.getOrDefault(
+  this, GroupStyling.REGULAR
+)

--- a/src/main/kotlin/com/markskelton/settings/Groups.kt
+++ b/src/main/kotlin/com/markskelton/settings/Groups.kt
@@ -1,0 +1,15 @@
+package com.markskelton.settings
+
+import com.markskelton.toOptional
+
+enum class Groups(val value: String) {
+  ATTRIBUTES("attributes"), COMMENTS("comments"), KEYWORDS("keywords")
+}
+
+private val groupMappings = Groups.values()
+  .map { it.value to it }
+  .toMap()
+
+fun String.toGroup(): Groups = groupMappings[this]
+  .toOptional()
+  .orElseThrow { IllegalStateException("Unknown grouping $this") }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -6,6 +6,18 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
 
+enum class GroupStyling(
+  val value: String
+) {
+  REGULAR("Regular"), ITALIC("Italic"), BOLD("Bold"), BOLD_ITALIC("Bold Italic")
+}
+private val styleMappings = GroupStyling.values()
+  .map { it.value to it }
+  .toMap()
+fun String.toGroupStyle(): GroupStyling = styleMappings.getOrDefault(
+  this, GroupStyling.REGULAR
+)
+
 @State(
     name = "OneDarkConfig",
     storages = [Storage("one_dark_config.xml")]
@@ -17,9 +29,10 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
 
     fun constructSettingModel(): ThemeSettingsModel {
       return ThemeSettingsModel(
-        instance.isBold,
-        instance.isVivid,
-        instance.isItalic
+        instance.commentStyle.toGroupStyle(),
+        instance.keywordStyle.toGroupStyle(),
+        instance.attributesStyle.toGroupStyle(),
+        instance.isVivid
       )
     }
   }
@@ -29,6 +42,9 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   var isBold: Boolean = false
   var isVivid: Boolean = false
   var isItalic: Boolean = false
+  var commentStyle: String = GroupStyling.REGULAR.value
+  var keywordStyle: String = GroupStyling.REGULAR.value
+  var attributesStyle: String = GroupStyling.REGULAR.value
   var customSchemeSet: Boolean = false
 
   override fun getState(): ThemeSettings? =

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -5,31 +5,6 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
-import com.markskelton.toOptional
-import java.lang.IllegalStateException
-
-enum class Groups(val value: String) {
-  ATTRIBUTES("attributes"), COMMENTS("comments"), KEYWORDS("keywords")
-}
-private val groupMappings = Groups.values()
-  .map { it.value to it }
-  .toMap()
-
-fun String.toGroup(): Groups = groupMappings[this]
-  .toOptional()
-  .orElseThrow { IllegalStateException("Unknown grouping $this") }
-
-enum class GroupStyling(
-  val value: String
-) {
-  REGULAR("Regular"), ITALIC("Italic"), BOLD("Bold"), BOLD_ITALIC("Bold Italic")
-}
-private val styleMappings = GroupStyling.values()
-  .map { it.value to it }
-  .toMap()
-fun String.toGroupStyle(): GroupStyling = styleMappings.getOrDefault(
-  this, GroupStyling.REGULAR
-)
 
 @State(
     name = "OneDarkConfig",

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -39,9 +39,7 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
 
   var version: String = "0.0.0"
   var userId: String = ""
-  var isBold: Boolean = false
   var isVivid: Boolean = false
-  var isItalic: Boolean = false
   var commentStyle: String = GroupStyling.REGULAR.value
   var keywordStyle: String = GroupStyling.REGULAR.value
   var attributesStyle: String = GroupStyling.REGULAR.value
@@ -55,9 +53,10 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   }
 
   fun asJson(): Map<String, Any> = mapOf(
-      "version" to version,
-      "isBold" to isBold,
-      "isVivid" to isVivid,
-      "isItalic" to isItalic
+    "version" to version,
+    "isVivid" to isVivid,
+    "attributesStyle" to attributesStyle,
+    "commentStyle" to commentStyle,
+    "keywordStyle" to keywordStyle
   )
 }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -5,6 +5,19 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
+import com.markskelton.toOptional
+import java.lang.IllegalStateException
+
+enum class Groups(val value: String) {
+  ATTRIBUTES("attributes"), COMMENTS("comments"), KEYWORDS("keywords")
+}
+private val groupMappings = Groups.values()
+  .map { it.value to it }
+  .toMap()
+
+fun String.toGroup(): Groups = groupMappings[this]
+  .toOptional()
+  .orElseThrow { IllegalStateException("Unknown grouping $this") }
 
 enum class GroupStyling(
   val value: String

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -136,7 +136,7 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
     )
     womboComboBox.model.selectedItem = initialValue.value
     womboComboBox.addActionListener {
-      handler(GroupStyling.valueOf(womboComboBox.model.selectedItem as String))
+      handler((womboComboBox.model.selectedItem as String).toGroupStyle())
     }
     return womboComboBox
   }

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.panel
 import com.markskelton.settings.ThemeSettings.Companion.constructSettingModel
 import java.net.URI
-import java.util.*
+import java.util.Vector
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JComponent
 
@@ -81,19 +81,19 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
     panel {
       titledRow("Font Styling") {
         row("Attributes") {
-            buildComboBox(themeSettingsModel.attributesStyle) {
-              themeSettingsModel.attributesStyle = it
-            }().focused()
+          buildComboBox(themeSettingsModel.attributesStyle) {
+            themeSettingsModel.attributesStyle = it
+          }().focused()
         }
         row("Comments") {
-            buildComboBox(themeSettingsModel.commentStyle) {
-              themeSettingsModel.commentStyle = it
-            }()
+          buildComboBox(themeSettingsModel.commentStyle) {
+            themeSettingsModel.commentStyle = it
+          }()
         }
         row("Keywords") {
-            buildComboBox(themeSettingsModel.keywordStyle) {
-              themeSettingsModel.keywordStyle = it
-            }()
+          buildComboBox(themeSettingsModel.keywordStyle) {
+            themeSettingsModel.keywordStyle = it
+          }()
         }
       }
       titledRow("Color Settings") {

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettingsUI.kt
@@ -57,6 +57,21 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
     }) {
       ThemeSettings.instance.isVivid = it
     }
+    registerSettingsChange(themeSettingsModel.attributesStyle.value, {
+      ThemeSettings.instance.attributesStyle
+    }) {
+      ThemeSettings.instance.attributesStyle = it
+    }
+    registerSettingsChange(themeSettingsModel.commentStyle.value, {
+      ThemeSettings.instance.commentStyle
+    }) {
+      ThemeSettings.instance.commentStyle = it
+    }
+    registerSettingsChange(themeSettingsModel.keywordStyle.value, {
+      ThemeSettings.instance.keywordStyle
+    }) {
+      ThemeSettings.instance.keywordStyle = it
+    }
   }
 
   override fun createComponent(): JComponent? =
@@ -127,7 +142,11 @@ class ThemeSettingsUI : DumbAware, SearchableConfigurable {
   }
 }
 
-fun <T> registerSettingsChange(setValue: T, getStoredValue: () -> T, onChanged: (T) -> Unit) {
+fun <T> registerSettingsChange(
+  setValue: T,
+  getStoredValue: () -> T,
+  onChanged: (T) -> Unit
+) {
   if (getStoredValue() != setValue) {
     onChanged(setValue)
   }

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -936,6 +936,7 @@
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -60,7 +60,7 @@
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="APACHE_CONFIG.IDENTIFIER">
@@ -101,20 +101,20 @@
     <option name="BASH.HERE_DOC_END">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="BASH.HERE_DOC_START">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_OPERATION_SIGN" name="BASH.REDIRECTION"/>
     <option name="BASH.SHEBANG">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%bold:always$italic:theme%"/>
+        <option name="FONT_TYPE" value="%bold:always$italic:theme^comments%"/>
       </value>
     </option>
     <option name="BLADE_DIRECTIVE">
@@ -221,7 +221,7 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="59626f"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
@@ -364,13 +364,13 @@
     <option name="CSS.IMPORTANT">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
@@ -395,7 +395,7 @@
       <value>
         <option name="EFFECT_COLOR" value="$whiskey$"/>
         <option name="FOREGROUND" value="$whiskey$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
         <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
@@ -409,7 +409,7 @@
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -456,7 +456,7 @@
     <option name="Clojure Line comment">
       <value>
         <option name="FOREGROUND" value="59626f"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="Clojure Literal">
@@ -536,7 +536,7 @@
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_CLASS_NAME">
@@ -560,7 +560,7 @@
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -614,7 +614,7 @@
     <option name="DEFAULT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="DEFAULT_LABEL">
@@ -625,13 +625,13 @@
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
@@ -722,7 +722,7 @@
     <option name="DJANGO_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="DJANGO_TAG_START_END">
@@ -810,7 +810,7 @@
     <option name="GO_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="GO_BUILTIN_CONSTANT">
@@ -852,13 +852,13 @@
     <option name="GO_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="GO_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="GO_LOCAL_FUNCTION">
@@ -894,7 +894,7 @@
     <option name="HAML_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="HAML_FILTER">
@@ -1027,7 +1027,7 @@
     <option name="JADE_STATEMENTS">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="JADE_TAG_CLASS">
@@ -1043,7 +1043,7 @@
     <option name="JAVA_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -1332,7 +1332,7 @@
     <option name="MARKDOWN_LINK_TITLE">
       <value>
         <option name="FOREGROUND" value="$green$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="MARKDOWN_TABLE_SEPARATOR">
@@ -1399,7 +1399,7 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="OC.LABEL">
@@ -1555,7 +1555,7 @@
     <option name="PY.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="PY.KEYWORD_ARGUMENT">
@@ -1576,7 +1576,7 @@
     <option name="PY.SELF_PARAMETER">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="PY.STRING">
@@ -1722,7 +1722,7 @@
     <option name="RUBY_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="RUBY_CONSTANT">
@@ -1905,7 +1905,7 @@
     <option name="SLIM_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
       </value>
     </option>
     <option name="SLIM_DOCTYPE_KWD">
@@ -1986,7 +1986,7 @@
     <option name="SWIFT_SHEBANG_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%bold:always$italic:theme%"/>
+        <option name="FONT_TYPE" value="%bold:always$italic:theme^comments%"/>
       </value>
     </option>
     <option baseAttributes="STATIC_METHOD_ATTRIBUTES" name="Static method access"/>
@@ -2016,7 +2016,7 @@
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ff8c00"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
       </value>
     </option>
     <option name="TS.MODULE_NAME">
@@ -2111,7 +2111,7 @@
     <option name="XPATH.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
@@ -2188,7 +2188,7 @@
     <option name="org.rust.LIFETIME">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
-        <option name="FONT_TYPE" value="%italic:theme%"/>
+        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
       </value>
     </option>
     <option name="org.rust.MACRO">

--- a/src/main/resources/templates/one-dark.template.xml
+++ b/src/main/resources/templates/one-dark.template.xml
@@ -60,7 +60,7 @@
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="APACHE_CONFIG.IDENTIFIER">
@@ -101,20 +101,20 @@
     <option name="BASH.HERE_DOC_END">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="BASH.HERE_DOC_START">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_OPERATION_SIGN" name="BASH.REDIRECTION"/>
     <option name="BASH.SHEBANG">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%bold:always$italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%bold$theme^comments%"/>
       </value>
     </option>
     <option name="BLADE_DIRECTIVE">
@@ -221,7 +221,7 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="59626f"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
@@ -232,7 +232,7 @@
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
@@ -243,7 +243,7 @@
     <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
@@ -270,7 +270,7 @@
     <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$green$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
@@ -281,7 +281,7 @@
     <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
@@ -302,7 +302,7 @@
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
@@ -328,7 +328,7 @@
     <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
@@ -364,13 +364,13 @@
     <option name="CSS.IMPORTANT">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
@@ -395,7 +395,7 @@
       <value>
         <option name="EFFECT_COLOR" value="$whiskey$"/>
         <option name="FOREGROUND" value="$whiskey$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
         <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
@@ -409,7 +409,7 @@
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -456,13 +456,13 @@
     <option name="Clojure Line comment">
       <value>
         <option name="FOREGROUND" value="59626f"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="Clojure Literal">
       <value>
         <option name="FOREGROUND" value="fda5ff"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="Clojure Numbers">
@@ -513,19 +513,19 @@
     <option name="DEBUGGER_INLINED_VALUES">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="DEBUGGER_INLINED_VALUES_EXECUTION_LINE">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="DEBUGGER_INLINED_VALUES_MODIFIED">
       <value>
         <option name="FOREGROUND" value="ff8c00"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="DEFAULT_ATTRIBUTE">
@@ -536,7 +536,7 @@
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_CLASS_NAME">
@@ -560,7 +560,7 @@
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -614,24 +614,24 @@
     <option name="DEFAULT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="DEFAULT_LABEL">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
@@ -722,7 +722,7 @@
     <option name="DJANGO_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="DJANGO_TAG_START_END">
@@ -775,7 +775,7 @@
     <option name="FIRST SYMBOL IN LIST">
       <value>
         <option name="FOREGROUND" value="df6a73"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -810,7 +810,7 @@
     <option name="GO_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="GO_BUILTIN_CONSTANT">
@@ -852,13 +852,13 @@
     <option name="GO_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="GO_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="GO_LOCAL_FUNCTION">
@@ -894,12 +894,12 @@
     <option name="HAML_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="HAML_FILTER">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="HAML_FILTER_CONTENT"/>
@@ -1020,14 +1020,14 @@
     </option>
     <option name="JADE_FILTER_NAME">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK"/>
     <option name="JADE_STATEMENTS">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="JADE_TAG_CLASS">
@@ -1043,7 +1043,7 @@
     <option name="JAVA_KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -1102,7 +1102,7 @@
     <option name="KOTLIN_ABSTRACT_CLASS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option baseAttributes="ANNOTATION_NAME_ATTRIBUTES" name="KOTLIN_ANNOTATION"/>
@@ -1117,13 +1117,13 @@
     <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="KOTLIN_ENUM_ENTRY">
@@ -1136,12 +1136,12 @@
     </option>
     <option name="KOTLIN_LABEL">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="KOTLIN_MUTABLE_VARIABLE">
       <value>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="KOTLIN_NAMED_ARGUMENT">
@@ -1162,7 +1162,7 @@
     <option name="KOTLIN_TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="KOTLIN_TYPE_PARAMETER">
@@ -1281,7 +1281,7 @@
     </option>
     <option name="MARKDOWN_BOLD">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="MARKDOWN_CODE_SPAN">
@@ -1326,13 +1326,13 @@
     </option>
     <option name="MARKDOWN_ITALIC">
       <value>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="MARKDOWN_LINK_TITLE">
       <value>
         <option name="FOREGROUND" value="$green$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="MARKDOWN_TABLE_SEPARATOR">
@@ -1399,13 +1399,13 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="OC.LABEL">
       <value>
         <option name="FOREGROUND" value="$lightWhite$"/>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="OC.MACRONAME">
@@ -1469,7 +1469,7 @@
     <option name="PHP_ALIAS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1555,7 +1555,7 @@
     <option name="PY.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="PY.KEYWORD_ARGUMENT">
@@ -1576,7 +1576,7 @@
     <option name="PY.SELF_PARAMETER">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="PY.STRING">
@@ -1722,7 +1722,7 @@
     <option name="RUBY_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="RUBY_CONSTANT">
@@ -1855,7 +1855,7 @@
     </option>
     <option name="ReSharper.IL_TARGET_CODE_LABEL">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="ReSharper.IL_VIEWER_SYNCHRONIZATION">
@@ -1905,7 +1905,7 @@
     <option name="SLIM_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%theme^comments%"/>
       </value>
     </option>
     <option name="SLIM_DOCTYPE_KWD">
@@ -1915,7 +1915,7 @@
     </option>
     <option name="SLIM_FILTER">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="SLIM_ID">
@@ -1986,7 +1986,7 @@
     <option name="SWIFT_SHEBANG_COMMENT">
       <value>
         <option name="FOREGROUND" value="$dark$"/>
-        <option name="FONT_TYPE" value="%bold:always$italic:theme^comments%"/>
+        <option name="FONT_TYPE" value="%bold$theme^comments%"/>
       </value>
     </option>
     <option baseAttributes="STATIC_METHOD_ATTRIBUTES" name="Static method access"/>
@@ -2016,7 +2016,7 @@
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ff8c00"/>
-        <option name="FONT_TYPE" value="%italic:theme^attributes%"/>
+        <option name="FONT_TYPE" value="%theme^attributes%"/>
       </value>
     </option>
     <option name="TS.MODULE_NAME">
@@ -2111,7 +2111,7 @@
     <option name="XPATH.KEYWORD">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
@@ -2162,7 +2162,7 @@
     </option>
     <option name="com.plan9.LABEL">
       <value>
-        <option name="FONT_TYPE" value="%bold:always%"/>
+        <option name="FONT_TYPE" value="%bold%"/>
       </value>
     </option>
     <option name="com.plan9.PSEUDO_INSTRUCTION">
@@ -2188,7 +2188,7 @@
     <option name="org.rust.LIFETIME">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
-        <option name="FONT_TYPE" value="%italic:theme^keywords%"/>
+        <option name="FONT_TYPE" value="%theme^keywords%"/>
       </value>
     </option>
     <option name="org.rust.MACRO">
@@ -2213,7 +2213,7 @@
     <option name="org.rust.TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic:always%"/>
+        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="org.rust.TYPE_PARAMETER">


### PR DESCRIPTION
# Motivation
- Fully addresses #145 
- Completes #139 

# Changes
Added the ability for the user to customize 3 syntax highlighting groups:
- `Attributes` (HTML Attributes, hyperlinks, annotations, etc).
- `Comments` (Single line, Multi line, etc).
- `Keywords` (Reserved words)
With the following style variants `Regular`, `Bold`, `Italic`, `Bold Italic`.

# Screenshot
![Screenshot from 2020-06-05 17-10-20](https://user-images.githubusercontent.com/15972415/83926786-7592d200-a750-11ea-86df-107b7c734826.png)
