### PR TITLE
Error Reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,20 @@ plugins {
 }
 
 group 'com.markskelton'
-version System.getenv('VERSION').replace('refs/tags/v', '')
+version System.getenv().getOrDefault('VERSION', '').replace('refs/tags/v', '')
 
 repositories {
     mavenCentral()
 }
+
+dependencies {
+  implementation 'io.sentry:sentry:1.7.30'
+}
+
+configurations {
+  implementation.exclude group: 'org.slf4j'
+}
+
 
 intellij {
     version 'LATEST-EAP-SNAPSHOT'

--- a/src/main/kotlin/com/markskelton/OneDarkTheme.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkTheme.kt
@@ -4,8 +4,15 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.markskelton.legacy.LegacyMigration
+import io.sentry.Sentry
 
 class OneDarkTheme : StartupActivity, DumbAware {
+
+  init {
+    Sentry.init("https://cb598170e51a44adbf0079abe2d79624@o403546.ingest.sentry.io/5267019?maxmessagelength=50000")
+  }
+
+
   override fun runActivity(project: Project) {
     LegacyMigration.migrateIfNecessary()
     OneDarkThemeManager.registerStartup(project)

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -24,11 +24,19 @@ object OneDarkThemeManager {
 
   fun registerStartup(project: Project) {
     if (!this::messageBus.isInitialized) {
+      registerUser()
+
       attemptToDisplayUpdates()
 
       applyConfigurableTheme()
 
       subscribeToEvents()
+    }
+  }
+
+  private fun registerUser() {
+    if (ThemeSettings.instance.userId.isEmpty()) {
+      ThemeSettings.instance.userId = UUID.randomUUID().toString()
     }
   }
 

--- a/src/main/kotlin/com/markskelton/integrations/ErrorReporter.kt
+++ b/src/main/kotlin/com/markskelton/integrations/ErrorReporter.kt
@@ -1,0 +1,122 @@
+package com.markskelton.integrations
+
+import com.intellij.ide.IdeBundle
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.ui.LafManager
+import com.intellij.openapi.application.ApplicationNamesInfo
+import com.intellij.openapi.application.ex.ApplicationInfoEx
+import com.intellij.openapi.application.impl.ApplicationInfoImpl
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtilRt
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.util.Consumer
+import com.intellij.util.text.DateFormatUtil
+import com.markskelton.settings.ThemeSettings
+import io.sentry.Sentry
+import io.sentry.event.Event
+import io.sentry.event.EventBuilder
+import io.sentry.event.UserBuilder
+import java.awt.Component
+import java.lang.management.ManagementFactory
+import java.text.SimpleDateFormat
+import java.util.Arrays
+import java.util.Properties
+import java.util.stream.Collectors
+
+class ErrorReporter : ErrorReportSubmitter() {
+  override fun getReportActionText(): String = "Report Anonymously"
+
+  override fun submit(
+    events: Array<out IdeaLoggingEvent>,
+    additionalInfo: String?,
+    parentComponent: Component,
+    consumer: Consumer<SubmittedReportInfo>
+  ): Boolean {
+    return try {
+      events.forEach {
+        Sentry.getContext().user =
+          UserBuilder().setId(ThemeSettings.instance.userId).build()
+        Sentry.capture(
+          addSystemInfo(
+            EventBuilder()
+              .withLevel(Event.Level.ERROR)
+              .withServerName(getAppName().second)
+              .withExtra("Message", it.message)
+              .withExtra("Additional Info", additionalInfo ?: "None")
+          ).withMessage(it.throwableText)
+        )
+        Sentry.clearContext()
+      }
+      true
+    } catch (e: Exception) {
+      false
+    }
+  }
+
+  private fun addSystemInfo(event: EventBuilder): EventBuilder {
+    val pair = getAppName()
+    val appInfo = pair.first
+    val appName = pair.second
+    val properties = System.getProperties()
+    return event
+      .withExtra("App Name", appName)
+      .withExtra("Build Info", getBuildInfo(appInfo))
+      .withExtra("JRE", getJRE(properties))
+      .withExtra("VM", getVM(properties))
+      .withExtra("System Info", SystemInfo.getOsNameAndVersion())
+      .withExtra("GC", getGC())
+      .withExtra("Memory", Runtime.getRuntime().maxMemory() / FileUtilRt.MEGABYTE)
+      .withExtra("Cores", Runtime.getRuntime().availableProcessors())
+      .withExtra("Registry", getRegistry())
+      .withExtra("Non-Bundled Plugins", getNonBundledPlugins())
+      .withExtra("Current LAF", LafManager.getInstance().currentLookAndFeel?.name)
+      .withExtra("One Dark Config", ThemeSettings.instance.asJson())
+  }
+
+  private fun getJRE(properties: Properties): String? {
+    val javaVersion = properties.getProperty("java.runtime.version", properties.getProperty("java.version", "unknown"))
+    val arch = properties.getProperty("os.arch", "")
+    return IdeBundle.message("about.box.jre", javaVersion, arch)
+  }
+
+  private fun getVM(properties: Properties): String? {
+    val vmVersion = properties.getProperty("java.vm.name", "unknown")
+    val vmVendor = properties.getProperty("java.vendor", "unknown")
+    return IdeBundle.message("about.box.vm", vmVersion, vmVendor)
+  }
+
+  private fun getNonBundledPlugins(): String? {
+    return Arrays.stream(PluginManagerCore.getPlugins())
+      .filter { p -> !p.isBundled && p.isEnabled }
+      .map { p -> p.pluginId.idString }.collect(Collectors.joining(","))
+  }
+
+  private fun getRegistry() = Registry.getAll().stream().filter { it.isChangedFromDefault }
+    .map { v -> v.key + "=" + v.asString() }.collect(Collectors.joining(","))
+
+  private fun getGC() = ManagementFactory.getGarbageCollectorMXBeans().stream()
+    .map { it.name }.collect(Collectors.joining(","))
+
+  private fun getBuildInfo(appInfo: ApplicationInfoImpl): String? {
+    var buildInfo = IdeBundle.message("about.box.build.number", appInfo.build.asString())
+    val cal = appInfo.buildDate
+    var buildDate = ""
+    if (appInfo.build.isSnapshot) {
+      buildDate = SimpleDateFormat("HH:mm, ").format(cal.time)
+    }
+    buildDate += DateFormatUtil.formatAboutDialogDate(cal.time)
+    buildInfo += IdeBundle.message("about.box.build.date", buildDate)
+    return buildInfo
+  }
+
+  private fun getAppName(): Pair<ApplicationInfoImpl, String> {
+    val appInfo = ApplicationInfoEx.getInstanceEx() as ApplicationInfoImpl
+    var appName = appInfo.fullApplicationName
+    val edition = ApplicationNamesInfo.getInstance().editionName
+    if (edition != null) appName += " ($edition)"
+    return Pair(appInfo, appName)
+  }
+}

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -25,6 +25,7 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   }
 
   var version: String = "0.0.0"
+  var userId: String = ""
   var isBold: Boolean = false
   var isVivid: Boolean = false
   var isItalic: Boolean = false

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
         <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>
         <applicationConfigurable groupId="appearance"
                                  instance="com.markskelton.settings.ThemeSettingsUI" />
+        <errorHandler id="9782e40c-e6d2-488f-8669-71f5cca6695e" implementation="com.markskelton.integrations.ErrorReporter"/>
         <postStartupActivity implementation="com.markskelton.OneDarkTheme" />
         <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
     </extensions>


### PR DESCRIPTION
# Motivation

Addresses: #147 

# Details

Implemented the `ErrorHandler` service interface that sends useful and anonymous (no PII) to https://sentry.io

# Example
Here is a sample exception that I forced to happen in the application:

![Screenshot from 2020-06-06 18-56-21](https://user-images.githubusercontent.com/15972415/83956940-b827dd80-a828-11ea-8a7d-9abec456302a.png)

Which was in-turn posted to:
https://sentry.io/share/issue/37b911b6809a4b5ea3f9692a1938bf2c/
