### PR TITLE
v5.1.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### Unreleased
+
+- Fixed a bug with the project file colors. [See the issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/192)
+
 #### 5.1.1
 
 - 2020.3 Build support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 #### Unreleased
 
+#### 5.1.2
+
 - Fixed a bug with the project file colors. [See the issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/192)
+- Fixed usability issue with the IntelliJ Ultimate UML Diagram. [See the issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/194)
+- Enhanced 2020.3 Welcome screen styling. [See the pull request for more details](https://github.com/one-dark/jetbrains-one-dark-theme/pull/193)
 
 #### 5.1.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ intellij {
   if("DEV" == System.getenv("ENV")){
     // Convenience tool for development to include other plugins
     setPlugins(
-      'indent-rainbow.indent-rainbow:1.5.1'
+      'indent-rainbow.indent-rainbow:1.6'
     )
   }
 }

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -5,7 +5,8 @@
   "editorScheme": "/themes/one_dark.xml",
   "colors": {
     "accentColor": "#568AF2",
-    "backgroundColor": "#21252b"
+    "backgroundColor": "#21252b",
+    "borderColor": "#333841"
   },
   "ui": {
     "*": {
@@ -179,6 +180,7 @@
 
     "Plugins": {
       "disabledForeground": "#5c6370",
+      "hoverBackground": "#323844",
       "lightSelectionBackground": "#323844",
       "tagBackground": "#414855",
       "tagForeground": "#abb2bf",
@@ -350,8 +352,13 @@
     },
 
     "WelcomeScreen": {
-      "Projects.selectionInactiveBackground": "#2c313a",
-      "separatorColor": "#2c313a"
+      "borderColor": "borderColor",
+      "Projects": {
+        "actions.background": "#323844",
+        "selectionInactiveBackground": "#2c313a"
+      },
+      "separatorColor": "#2c313a",
+      "SidePanel.background": "#282c34"
     }
   },
 

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -121,12 +121,12 @@
     },
 
     "FileColor": {
-      "Yellow": "#563b2255",
-      "Green": "#334e1f55",
-      "Blue": "#28436d55",
-      "Violet": "#37115655",
-      "Orange": "#562b2255",
-      "Rose": "#561a2b55"
+      "Yellow": "#3d3026",
+      "Green": "#293a24",
+      "Blue": "#24354f",
+      "Violet": "#2d1942",
+      "Orange": "#3d3026",
+      "Rose": "#3d1e2b"
     },
 
     "Label": {

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -11,8 +11,7 @@ import com.intellij.ui.IconManager
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>2020.3 Build Support.</li>
-        <li>Better VCS commit view styling.</li>
+        <li>Fixed bug with file colors.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -12,6 +12,8 @@ val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
         <li>Fixed bug with file colors.</li>
+        <li>Usability issue with IntelliJ Ultimate UML Diagram.</li>
+        <li>Enhanced 2020.3 welcome screen styling.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
# Motivation

Closes #192 
Closes #194 

For whatever reason, the platform does not handle the colors with alpha values. So rather than have the real issue fixed, I opted to use the evaluated colors when put against `#21252B` 

![image](https://user-images.githubusercontent.com/15972415/96056159-6f71d800-0e4b-11eb-977e-934fcd184e21.png)

It also too me a good solid 45 mins to find that this is set by the LAF :facepalm: , well I know this feature exists now!

Also enhanced the styling of the new 2020.3 Welcome Screen

| Before | After |
| --- | --- |
| ![Screenshot from 2020-10-18 08-32-44](https://user-images.githubusercontent.com/15972415/96369354-fdd1ac80-111e-11eb-9e4e-4aae1e6ad85b.png) | ![Screenshot from 2020-10-18 08-39-06](https://user-images.githubusercontent.com/15972415/96369355-03c78d80-111f-11eb-8c70-23d6703387ac.png) |

