### PR TITLE
v5.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+#### 5.1.3
+
+- Fixed the problem with Typescript Type Guard not showing up. [See issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/198)
+- Updated VCS log list hover color.
+
 #### 5.1.2
 
 - Fixed a bug with the project file colors. [See the issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/192)

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ configurations {
 
 intellij {
   version 'LATEST-EAP-SNAPSHOT'
-  type 'IU'
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 
   if("DEV" == System.getenv("ENV")){

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ intellij {
 
   if("DEV" == System.getenv("ENV")){
     // Convenience tool for development to include other plugins
-//    setPlugins(
-//      'indent-rainbow.indent-rainbow:1.6'
-//    )
+    setPlugins(
+      'indent-rainbow.indent-rainbow:1.6'
+    )
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,14 @@ configurations {
 
 intellij {
   version 'LATEST-EAP-SNAPSHOT'
+  type 'IU'
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
 
   if("DEV" == System.getenv("ENV")){
     // Convenience tool for development to include other plugins
-    setPlugins(
-      'indent-rainbow.indent-rainbow:1.6'
-    )
+//    setPlugins(
+//      'indent-rainbow.indent-rainbow:1.6'
+//    )
   }
 }
 

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -591,12 +591,10 @@
     <option name="DEFAULT_GLOBAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="$coral$" />
-        <option name="BACKGROUND" value="282c34" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="BACKGROUND" value="282c34"/>
         <option name="FOREGROUND" value="$lightWhite$"/>
       </value>
     </option>
@@ -676,7 +674,6 @@
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="BACKGROUND" value="282c34"/>
         <option name="FOREGROUND" value="$lightWhite$"/>
       </value>
     </option>
@@ -959,7 +956,6 @@
     </option>
     <option name="HAML_TEXT">
       <value>
-        <option name="BACKGROUND" value="282c34"/>
         <option name="FOREGROUND" value="$lightWhite$"/>
       </value>
     </option>
@@ -2016,7 +2012,6 @@
     <option baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" name="SLIM_RUBY_CODE"/>
     <option name="SLIM_STATIC_CONTENT">
       <value>
-        <option name="BACKGROUND" value="282c34"/>
         <option name="FOREGROUND" value="$lightWhite$"/>
       </value>
     </option>
@@ -2106,6 +2101,11 @@
     <option name="TS.MODULE_NAME">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
+      </value>
+    </option>
+    <option name="TS.TYPE_GUARD">
+      <value>
+        <option name="BACKGROUND" value="2A3B33"/>
       </value>
     </option>
     <option name="TS.TYPE_PARAMETER">
@@ -2343,7 +2343,6 @@
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
         <option name="FOREGROUND" value="$chalky$" />
-        <option name="BACKGROUND" value="282c34" />
       </value>
     </option>
   </attributes>

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -341,6 +341,7 @@
     "VersionControl": {
       "Log.Commit": {
         "currentBranchBackground": "#282c35",
+        "hoveredBackground": "#2c313c",
         "unmatchedForeground": "#5c6370"
       },
 

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -44,7 +44,7 @@ object Notifications {
       "$pluginName updated to v$versionNumber",
       UPDATE_MESSAGE,
       NotificationType.INFORMATION,
-      NotificationListener.URL_OPENING_LISTENER
+      NotificationListener.UrlOpeningListener(false)
     )
       .setIcon(NOTIFICATION_ICON)
       .notify(null)

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -11,9 +11,8 @@ import com.intellij.ui.IconManager
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>Fixed bug with file colors.</li>
-        <li>Usability issue with IntelliJ Ultimate UML Diagram.</li>
-        <li>Enhanced 2020.3 welcome screen styling.</li>
+        <li>Fixed bug with Typescript Type Guards.</li>
+        <li>Updated styling of the VCS log hover color.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
# Motivation

Closes #198 

## Details

- Removed all of the places where the background was being set to the editor color background, and just left it where it was needed. That way any other backgrounds do not get removed, which could result in a similar issue to #198 
- Also added the version control log list hover color.

## Screens

**Typeguard**
![image](https://user-images.githubusercontent.com/15972415/102718639-c8784500-42ae-11eb-8817-6f4a9949b761.png)

**VCS Log List Hover**

![Peek 2020-12-20 10-30](https://user-images.githubusercontent.com/15972415/102718653-de860580-42ae-11eb-8cec-d7caf92b1139.gif)
