### PR TITLE
2021 Build Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+#### 5.1.4
+
+- 2021.1 EAP build support!
+- Updated the foreground coloring of the Windows 10 Title bar
+
 #### 5.1.3
 
 - Fixed the problem with Typescript Type Guard not showing up. [See issue for more details](https://github.com/one-dark/jetbrains-one-dark-theme/issues/198)

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'io.sentry:sentry:1.7.30'
+  implementation 'io.sentry:sentry:4.0.0'
   implementation 'commons-io:commons-io:2.6'
   implementation'org.codehaus.groovy:groovy-xml:2.5.11'
 }
@@ -27,13 +27,6 @@ configurations {
 intellij {
   version 'LATEST-EAP-SNAPSHOT'
   alternativeIdePath  project.hasProperty("idePath") ? project.findProperty("idePath") : ""
-
-  if("DEV" == System.getenv("ENV")){
-    // Convenience tool for development to include other plugins
-    setPlugins(
-      'indent-rainbow.indent-rainbow:1.6'
-    )
-  }
 }
 
 compileKotlin {

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -6,7 +6,8 @@
   "colors": {
     "accentColor": "#568AF2",
     "backgroundColor": "#21252b",
-    "borderColor": "#333841"
+    "borderColor": "#333841",
+    "infoForeground": "#7e8491"
   },
   "ui": {
     "*": {
@@ -131,7 +132,7 @@
     },
 
     "Label": {
-      "infoForeground": "#7e8491"
+      "infoForeground": "infoForeground"
     },
 
     "Link": {
@@ -323,6 +324,11 @@
         "selectedBackground": "#323844",
         "selectedInactiveBackground": "#3d424b"
       }
+    },
+
+    "TitlePane" : {
+      "infoForeground": "infoForeground",
+      "inactiveInfoForeground": "#5C6370"
     },
 
     "Tree": {

--- a/src/main/kotlin/com/markskelton/integrations/ErrorReporter.kt
+++ b/src/main/kotlin/com/markskelton/integrations/ErrorReporter.kt
@@ -15,12 +15,10 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.Consumer
 import com.intellij.util.text.DateFormatUtil
 import com.markskelton.settings.ThemeSettings
-import io.sentry.DefaultSentryClientFactory
-import io.sentry.SentryClient
-import io.sentry.dsn.Dsn
-import io.sentry.event.Event
-import io.sentry.event.EventBuilder
-import io.sentry.event.UserBuilder
+import com.markskelton.tools.runSafelyWithResult
+import io.sentry.*
+import io.sentry.protocol.Message
+import io.sentry.protocol.User
 import java.awt.Component
 import java.lang.management.ManagementFactory
 import java.text.SimpleDateFormat
@@ -30,16 +28,24 @@ import java.util.stream.Collectors
 
 class ErrorReporter : ErrorReportSubmitter() {
   override fun getReportActionText(): String = "Report Anonymously"
-
   companion object {
-    private val sentryClient: SentryClient =
-      DefaultSentryClientFactory().createSentryClient(Dsn(
-        RestClient.performGet(
-          "https://jetbrains.assets.unthrottled.io/one-dark/sentry-dsn.txt"
-        )
-          .map { it.trim() }
-          .orElse("https://cb598170e51a44adbf0079abe2d79624@o403546.ingest.sentry.io/5267019?maxmessagelength=50000")
-      ))
+
+    init {
+      Sentry.init { options: SentryOptions ->
+        options.dsn =
+          RestClient.performGet(
+            "https://jetbrains.assets.unthrottled.io/one-dark/sentry-dsn.txt"
+          )
+            .map { it.trim() }
+            .orElse("https://cb598170e51a44adbf0079abe2d79624@o403546.ingest.sentry.io/5267019?maxmessagelength=50000")
+      }
+
+      Sentry.setUser(
+        User().apply {
+          this.id = ThemeSettings.instance.userId
+        }
+      )
+    }
   }
 
   override fun submit(
@@ -48,45 +54,48 @@ class ErrorReporter : ErrorReportSubmitter() {
     parentComponent: Component,
     consumer: Consumer<in SubmittedReportInfo>
   ): Boolean {
-    return try {
+    return runSafelyWithResult({
       events.forEach {
-        sentryClient.context.user =
-          UserBuilder().setId(ThemeSettings.instance.userId).build()
-        sentryClient.sendEvent(
+        Sentry.captureEvent(
           addSystemInfo(
-            EventBuilder()
-              .withLevel(Event.Level.ERROR)
-              .withServerName(getAppName().second)
-              .withExtra("Message", it.message)
-              .withExtra("Additional Info", additionalInfo ?: "None")
-          ).withMessage(it.throwableText)
+            SentryEvent()
+              .apply {
+                this.level = SentryLevel.ERROR
+                this.serverName = getAppName().second
+                this.setExtra("Additional Info", additionalInfo ?: "None")
+              }
+          ).apply {
+            this.message = Message().apply {
+              this.message = it.throwableText
+            }
+          }
         )
-        sentryClient.clearContext()
       }
       true
-    } catch (e: Exception) {
+    }) {
       false
     }
   }
 
-  private fun addSystemInfo(event: EventBuilder): EventBuilder {
+  private fun addSystemInfo(event: SentryEvent): SentryEvent {
     val pair = getAppName()
     val appInfo = pair.first
     val appName = pair.second
     val properties = System.getProperties()
-    return event
-      .withExtra("App Name", appName)
-      .withExtra("Build Info", getBuildInfo(appInfo))
-      .withExtra("JRE", getJRE(properties))
-      .withExtra("VM", getVM(properties))
-      .withExtra("System Info", SystemInfo.getOsNameAndVersion())
-      .withExtra("GC", getGC())
-      .withExtra("Memory", Runtime.getRuntime().maxMemory() / FileUtilRt.MEGABYTE)
-      .withExtra("Cores", Runtime.getRuntime().availableProcessors())
-      .withExtra("Registry", getRegistry())
-      .withExtra("Non-Bundled Plugins", getNonBundledPlugins())
-      .withExtra("Current LAF", LafManager.getInstance().currentLookAndFeel?.name)
-      .withExtra("One Dark Config", ThemeSettings.instance.asJson())
+    return event.apply {
+      setExtra("App Name", appName)
+      setExtra("Build Info", getBuildInfo(appInfo))
+      setExtra("JRE", getJRE(properties))
+      setExtra("VM", getVM(properties))
+      setExtra("System Info", SystemInfo.getOsNameAndVersion())
+      setExtra("GC", getGC())
+      setExtra("Memory", Runtime.getRuntime().maxMemory() / FileUtilRt.MEGABYTE)
+      setExtra("Cores", Runtime.getRuntime().availableProcessors())
+      setExtra("Registry", getRegistry())
+      setExtra("Non-Bundled Plugins", getNonBundledPlugins())
+      setExtra("Current LAF", LafManager.getInstance().currentLookAndFeel?.name)
+      setExtra("One Dark Config", ThemeSettings.instance.asJson())
+    }
   }
 
   private fun getJRE(properties: Properties): String? {

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -7,12 +7,14 @@ import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.ui.IconManager
+import org.intellij.lang.annotations.Language
 
+@Language("HTML")
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>Fixed bug with Typescript Type Guards.</li>
-        <li>Updated styling of the VCS log hover color.</li>
+        <li>2021.1 EAP Support</li>
+        <li>Updated Windows 10 Title pane foreground</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -26,7 +26,6 @@ object Notifications {
     Notifications::class.java
   )
 
-
   private val notificationGroup = NotificationGroup(
     "One Dark Theme",
     NotificationDisplayType.BALLOON,

--- a/src/main/kotlin/com/markskelton/tools/ToolBox.kt
+++ b/src/main/kotlin/com/markskelton/tools/ToolBox.kt
@@ -1,0 +1,8 @@
+package com.markskelton.tools
+
+fun <T> runSafelyWithResult(runner: () -> T, onError: (Throwable) -> T): T =
+  try {
+    runner()
+  } catch (e: Throwable) {
+    onError(e)
+  }


### PR DESCRIPTION
# Changes

- Updated Windows 10 Title Pane Foreground (Closes #203 )
- Updated Sentry Client
- Triggering a new build on release will also add 2021.1 build support (Closes #204)

## Screen Shot
| Before | After |
| --- | --- |
| ![Image](https://user-images.githubusercontent.com/15972415/103347427-9b6d2480-4a5c-11eb-8fea-180992cca63d.png) | ![image](https://user-images.githubusercontent.com/15972415/106359049-a0c8c380-62d5-11eb-9e8b-0b03717d0a57.png) |
