### PR TITLE
v5.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+#### 5.1.5
+
+- Added identifier under caret error stripe color.
+- Themed Default Inlays
+
 #### 5.1.4
 
 - 2021.1 EAP build support!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added identifier under caret error stripe color.
 - Themed Default Inlays
+- Updated Ruby's local variable foreground color.
 
 #### 5.1.4
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ repositories {
 dependencies {
   implementation 'io.sentry:sentry:4.0.0'
   implementation 'commons-io:commons-io:2.6'
-  implementation'org.codehaus.groovy:groovy-xml:2.5.11'
 }
 
 configurations {

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -1017,6 +1017,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="353940"/>
+        <option name="ERROR_STRIPE_COLOR" value="4d78cc" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
@@ -1042,6 +1043,12 @@
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value/>
+    </option>
+    <option name="INLAY_DEFAULT">
+      <value>
+        <option name="BACKGROUND" value="414855"/>
+        <option name="FOREGROUND" value="$lightWhite$"/>
+      </value>
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -1855,7 +1855,11 @@
     <option name="RUBY_LINE_CONTINUATION">
       <value/>
     </option>
-    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="RUBY_LOCAL_VAR_ID"/>
+    <option name="RUBY_LOCAL_VAR_ID">
+      <value>
+        <option name="FOREGROUND" value="$whiskey$" />
+      </value>
+    </option>
     <option baseAttributes="DEFAULT_INSTANCE_METHOD" name="RUBY_METHOD_NAME"/>
     <option name="RUBY_NTH_REF">
       <value>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -13,8 +13,8 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>2021.1 EAP Support</li>
-        <li>Updated Windows 10 Title pane foreground</li>
+        <li>Added identifier under caret error stripe color.</li>
+        <li>Themed Default Inlays</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -15,6 +15,7 @@ val UPDATE_MESSAGE: String = """
       <ul>
         <li>Added identifier under caret error stripe color.</li>
         <li>Themed Default Inlays</li>
+        <li>Update Ruby's local variable color</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes

- Added identifier under caret error stripe color.
- Themed Default Inlays
- Updated Ruby's local variable foreground color.


## Motivation

Closes #208 
Closes #207 

## Screenshots

![image](https://user-images.githubusercontent.com/15972415/109298292-f58a2c00-77f8-11eb-8f9d-df11956a89a2.png)

![image](https://user-images.githubusercontent.com/15972415/109388216-6732aa80-78cb-11eb-9e8c-10d5d686414f.png)

