### PR TITLE
Addressing UI Freezing Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Unreleased
 
+- Fixed UI Freeze issues
+
 #### 5.1.5
 
 - Added identifier under caret error stripe color.

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -13,9 +13,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>Added identifier under caret error stripe color.</li>
-        <li>Themed Default Inlays</li>
-        <li>Update Ruby's local variable color</li>
+        <li>Fixed UI Freezing issue.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes

- Fetching remote error reporting configuration not on the AWT thread.

## Motivation
Should fix #214 
- Prevents UI freezes when internet connections are slow.

## Extra Notes:

I am debating removing the error reporting, because there are not a lot of moving parts in the plugin anymore. Users would lose the ability to report any exceptions and they would have to manually email @mskelton . 