### PR TITLE
2021.2 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Unreleased
 
+#### 5.3.1
+
+- Restored autocomplete window coloring in 2021.2 builds.
+
 #### 5.3.0
 
 - Plugin is now compatible with the `Code With Me` platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 5.3.1
 
+- Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
 - Restored autocomplete window coloring in 2021.2 builds.
 
 #### 5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
 - Restored autocomplete window coloring in 2021.2 builds.
+- Made bookmark icon visible in favorites tree.
 
 #### 5.3.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'one-dark-theme-plugin'
     id 'org.jetbrains.intellij' version '1.1.4'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.10'
     id 'org.jlleitschuh.gradle.ktlint' version '8.2.0'
     id 'org.kordamp.gradle.markdown' version '2.2.0'
 }
@@ -24,7 +24,7 @@ configurations {
 
 
 intellij {
-  version.set('2021.1.3')
+  version.set('2021.2')
 }
 
 compileKotlin {

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -34,6 +34,7 @@
     <option name="INFORMATION_HINT" value="3d424b"/>
     <option name="LINE_NUMBERS_COLOR" value="495162"/>
     <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="737984"/>
+    <option name="LOOKUP_COLOR" value="3d424b"/>
     <option name="METHOD_SEPARATORS_COLOR" value="3b4048"/>
     <option name="MODIFIED_LINES_COLOR" value="$whiskey$"/>
     <option name="QUESTION_HINT" value="2e4280"/>

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -7,7 +7,8 @@
     "accentColor": "#568AF2",
     "backgroundColor": "#21252b",
     "borderColor": "#333841",
-    "infoForeground": "#7e8491"
+    "infoForeground": "#7e8491",
+    "foregroundColor": "#abb2bf"
   },
   "ui": {
     "*": {
@@ -353,6 +354,7 @@
     "Tree": {
       "selectionBackground": "#4d78cc",
       "modifiedItemForeground": "accentColor",
+      "selectionInactiveForeground": "foregroundColor",
       "rowHeight": 20
     },
 

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -45,6 +45,8 @@
       "pressedBorderColor": "#333841"
     },
 
+    "BookmarkIcon.background": "#d9a343",
+
     "Button": {
       "foreground": "#a0a7b4",
       "startBackground": "#3d424b",

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -83,6 +83,7 @@
     "ComboPopup.border": "1,1,1,1,2d3137",
 
     "CompletionPopup":  {
+      "background": "#3d424b",
       "matchForeground": "accentColor"
     },
 

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -141,7 +141,14 @@
     },
 
     "Label": {
-      "infoForeground": "infoForeground"
+      "infoForeground": "infoForeground",
+      "successForeground": "#89ca78"
+    },
+
+    "Lesson": {
+      "Tooltip.background" : "#3d424b",
+      "Tooltip.spanBackground" : "accentColor",
+      "Tooltip.foreground" : "#ffffff"
     },
 
     "Link": {

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -13,6 +13,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
+        <li>IDE Features Trainer theming.</li>
         <li>Better 2021.2 build support.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -13,7 +13,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>Added Code With Me Support</li>
+        <li>Better 2021.2 build support.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -15,6 +15,7 @@ val UPDATE_MESSAGE: String = """
       <ul>
         <li>IDE Features Trainer theming.</li>
         <li>Better 2021.2 build support.</li>
+        <li>Made bookmark icon visible in favorites tree.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
# Changes

- Updated completion popup to look the way it did before.
- Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.
- Fixed bookmark icon color in favorites tree view

# Motivation

Fixes #224 
Fixes #229 

# Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15972415/127477619-4a513b4a-1d47-4cab-ac2e-ee042dec53ac.png) | ![image](https://user-images.githubusercontent.com/15972415/127477764-18f103df-70c4-4a81-a752-775b8e1420ba.png) |
| ![Screenshot from 2021-09-05 10-40-20](https://user-images.githubusercontent.com/15972415/132133237-f1d3f5c4-a84a-47f0-9bf8-6e4736ade5f2.png) | ![Screenshot from 2021-09-05 10-46-43](https://user-images.githubusercontent.com/15972415/132133244-24f73101-a38f-41cf-aec6-1efc893173f6.png) |
| ![Screenshot from 2021-09-17 05-28-46](https://user-images.githubusercontent.com/15972415/133769069-01db3c47-e5ec-4878-bd06-3646950334b7.png) | ![Screenshot from 2021-09-17 05-31-53](https://user-images.githubusercontent.com/15972415/133769097-9acec201-3cfc-49c7-b775-7fc50033025a.png) |





