### PR TITLE
Updated to 2021.3 build

### DIFF
--- a/.github/workflows/preMerge.yml
+++ b/.github/workflows/preMerge.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: ChrisCarini/intellij-platform-plugin-verifier-action@v1.0.7
       with:
         ide-versions: |
-          ideaIC:2020.1.2
-          ideaIU:2020.1.2
+          ideaIC:2020.3
+          ideaIU:2020.3
           ideaIC:LATEST-EAP-SNAPSHOT
           ideaIU:LATEST-EAP-SNAPSHOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### 5.4.0
 
-- Plugin only supports 2021.3+ platform builds now.
+- Plugin only supports 2020.3 to 2021.3.X platform builds now.
 
 #### 5.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Unreleased
 
+#### 5.4.0
+
+- Plugin only supports 2021.3+ platform builds now.
+
 #### 5.3.1
 
 - Updates the colors used by the [IDE Features Trainer](https://plugins.jetbrains.com/plugin/8554-ide-features-trainer) plugin, for a more consistent learning experience.

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ tasks.runPluginVerifier {
 }
 
 tasks.patchPluginXml {
-    sinceBuild.set('213')
+    sinceBuild.set('203.7148.57')
     untilBuild.set('213.*')
 
     def changelogPath = "$projectDir/build/html/CHANGELOG.html"

--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,14 @@ tasks.runIde {
 
 tasks.runPluginVerifier {
   ideVersions.set([
-    "IC-2020.1.2", "IC-2021.1.3", "PY-2021.1.3"
+// will bring this back when able to verify on 2021.3 builds
+//    "IC-2021.3",
   ])
 }
 
 tasks.patchPluginXml {
-    sinceBuild.set('201.5985.32')
-    untilBuild.set('212.*')
+    sinceBuild.set('213')
+    untilBuild.set('213.*')
 
     def changelogPath = "$projectDir/build/html/CHANGELOG.html"
     def readmePath = "$projectDir/build/html/README.html"

--- a/src/main/kotlin/OneDarkIcons.kt
+++ b/src/main/kotlin/OneDarkIcons.kt
@@ -1,0 +1,9 @@
+package icons
+
+import com.intellij.openapi.util.IconLoader
+
+object OneDarkIcons {
+
+  @JvmField
+  val LOGO = IconLoader.getIcon("/icons/one-dark-logo.svg", javaClass)
+}

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -12,7 +12,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>2021.3 build support.</li>
+        <li>Added 2021.3 build support.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -2,8 +2,7 @@ package com.markskelton.notification
 
 import com.intellij.ide.plugins.PluginManagerCore.getPlugin
 import com.intellij.ide.plugins.PluginManagerCore.getPluginOrPlatformByClassName
-import com.intellij.notification.NotificationDisplayType
-import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.ui.IconManager
@@ -13,9 +12,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>IDE Features Trainer theming.</li>
-        <li>Better 2021.2 build support.</li>
-        <li>Made bookmark icon visible in favorites tree.</li>
+        <li>2021.3 build support.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>
@@ -29,13 +26,7 @@ object Notifications {
     Notifications::class.java
   )
 
-  private val notificationGroup = NotificationGroup(
-    "One Dark Theme",
-    NotificationDisplayType.BALLOON,
-    false,
-    "One Dark Theme",
-    NOTIFICATION_ICON
-  )
+  private val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("One Dark Theme")
 
   fun displayUpdateNotification(versionNumber: String) {
     val pluginName =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
   <!--    Leave this in here so the IDE gives you feedback on-->
   <!--    What API's are available-->
-  <idea-version since-build="213"/>
+  <idea-version since-build="203.7148.57"/>
 
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,12 +9,13 @@
 
   <!--    Leave this in here so the IDE gives you feedback on-->
   <!--    What API's are available-->
-  <idea-version since-build="201.5985.32"/>
+  <idea-version since-build="213"/>
 
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceImplementation="com.markskelton.settings.ThemeSettings"/>
     <errorHandler id="9782e40c-e6d2-488f-8669-71f5cca6695e"
                   implementation="com.markskelton.integrations.ErrorReporter"/>
+    <notificationGroup displayType="BALLOON" id="One Dark Theme" icon="OneDarkIcons.LOGO" isLogByDefault="false" toolWindowId="One Dark Theme"  />
     <postStartupActivity implementation="com.markskelton.OneDarkTheme"/>
     <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
     <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>


### PR DESCRIPTION
## Description

- Adds support for 2020.3 to 2021.3.x builds, because the notification API changes in 2021.3, and makes backwards compatibility not so simple. So opted to cap lowest supported version to 2020.3 for v5.4+ of this plugin.

## Motivation

Closes #233 

## Notes

Verified that this works on 

```
WebStorm 2021.3 EAP
Build #WS-213.3714.441, built on September 22, 2021
WebStorm EAP User
Expiration date: October 22, 2021
Runtime version: 11.0.12+7-b1649.1 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Linux 5.4.0-84-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 4096M
Cores: 12
Registry:
    ide.new.color.picker=false
    ide.balloon.shadow.size=0
    eslint.additional.file.extensions=svelte

Non-Bundled Plugins:
    net.seesharpsoft.intellij.plugins.csv (2.17.1)
    com.markskelton.one-dark-theme (5.4.0)
    String Manipulation (8.15.203.000.3)
    IdeaVIM (1.7.0)
    dev.blachut.svelte.lang (0.21.0)

Current Desktop: ubuntu:GNOME
```

Here is the release if anybody wants to get their hands on it asap
[one-dark-theme-5.4.0.zip](https://github.com/one-dark/jetbrains-one-dark-theme/files/7221298/one-dark-theme-5.4.0.zip)

Will release this when I've had a bit more time to go over the changes.


