### PR TITLE
Added Error Stripe Mark to Identifiers Under Caret.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+#### 5.5.2
+
+- Added `Error Stripe Mark` to identifiers under caret.
+
+
 #### 5.5.1
 
 - Better 2022.1 Build Support

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ configurations {
 }
 
 intellij {
-  version.set('LATEST-EAP-SNAPSHOT')
+  version.set('2021.3')
   type.set('IC')
   downloadSources.set(true)
   updateSinceUntilBuild.set(true)

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -1080,6 +1080,7 @@
       <value>
         <option name="BACKGROUND" value="353940"/>
         <option name="ERROR_STRIPE_COLOR" value="4d78cc" />
+        <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
@@ -2263,6 +2264,8 @@
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="353940"/>
+        <option name="ERROR_STRIPE_COLOR" value="4d78cc" />
+        <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -12,8 +12,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-          <li>Better 2022.1 Build Support</li>
-          <li>Updated Cucumber syntax highlighting a bit</li>
+          <li>Added <code>Error Stripe Mark</code> to identifers under caret</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -12,7 +12,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-          <li>Added <code>Error Stripe Mark</code> to identifers under caret</li>
+          <li>Added <code>Error Stripe Mark</code> to identifiers under caret</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes

- Added `Error Stripe Mark` to identifiers under caret

## Motivation

Closes #252 

## Screens

| Before | After |
| --- | --- |
|<img width="395" alt="Screen Shot 2022-04-10 at 12 50 02 PM" src="https://user-images.githubusercontent.com/15972415/162633146-34200d28-4120-4ccb-8e7b-7defea1e0f49.png"> | <img width="355" alt="Screen Shot 2022-04-10 at 12 48 16 PM" src="https://user-images.githubusercontent.com/15972415/162633151-326eac9e-45cb-4c0b-8526-591cf6cbd572.png"> |
 