### PR TITLE
Added Initial 2022.2 Build Support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Unreleased
 
+#### 5.6.0
+
+- Added initial 2022.2 Build Support.
+
 #### 5.5.2
 
 - Added `Error Stripe Mark` to identifiers under caret.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'one-dark-theme-plugin'
-    id 'org.jetbrains.intellij' version '1.2.0'
+    id 'org.jetbrains.intellij' version '1.5.2'
     id 'org.jetbrains.kotlin.jvm' version '1.5.10'
     id 'org.jlleitschuh.gradle.ktlint' version '8.2.0'
     id 'org.kordamp.gradle.markdown' version '2.2.0'
@@ -59,7 +59,7 @@ tasks.runPluginVerifier {
 
 tasks.patchPluginXml {
     sinceBuild.set('203.7148.57')
-    untilBuild.set('221.*')
+    untilBuild.set('222.*')
 
     def changelogPath = "$projectDir/build/html/CHANGELOG.html"
     def readmePath = "$projectDir/build/html/README.html"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -12,7 +12,7 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-          <li>Added <code>Error Stripe Mark</code> to identifiers under caret</li>
+          <li>Added initial 2022.2 Build Support</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes

- Added initial 2022.2 Build Support.

## Motivation

The first [2022.2 EAP is out.](https://blog.jetbrains.com/idea/2022/05/intellij-idea-2022-2-eap-1/?utm_source=product&utm_medium=link&utm_campaign=TBA)