### PR TITLE
v5.7.1 - Usability Updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+#### 5.7.1
+
+- Better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)
+- Inverted indeterminate progress bar colors to better support [running Jupyter notebook progression indicator](https://github.com/one-dark/jetbrains-one-dark-theme/issues/268) 
+
 #### 5.7.0
 
 - 2022.3 Build Support.

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -305,12 +305,12 @@
     "ProgressBar": {
       "trackColor": "#1D1D26",
       "progressColor": "accentColor",
-      "indeterminateStartColor": "accentColor",
-      "indeterminateEndColor": "#313469",
-      "failedColor": "#bd3c5f",
-      "failedEndColor": "#472c33",
-      "passedColor": "#239E62",
-      "passedEndColor": "#2b4242"
+      "indeterminateStartColor": "#313469",
+      "indeterminateEndColor": "accentColor",
+      "failedColor": "#472c33",
+      "failedEndColor": "#bd3c5f",
+      "passedColor": "#2b4242",
+      "passedEndColor": "#239E62"
     },
 
     "SearchEverywhere": {

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -275,6 +275,11 @@
         "updateBorderColor": "accentColor"
       },
 
+      "RunWidget": {
+        "foreground": "#eef3ff",
+        "background": "accentColor"
+      },
+
       "SearchField": {
         "background": "#282c34",
         "borderColor": "#1b1d21"

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -13,9 +13,8 @@ import org.intellij.lang.annotations.Language
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-          <li>Initial 2022.3 Build Support.</li>
-          <li>Better Experimental UI Support.</li>
-          <li>Fixed highlighted terminal commands.</li>
+          <li>More Usable Experimental UI Run Widget</li>
+          <li>More Visible Jupyter Notebook progression bar.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes


- Better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)
- Inverted indeterminate progress bar colors to better support [running Jupyter notebook progression indicator](https://github.com/one-dark/jetbrains-one-dark-theme/issues/268) 

## Motivation

Fixes #271
Fixes #268

## Screens

**Jupyter Notebook**
![image](https://user-images.githubusercontent.com/15972415/201447334-6491bf9f-a3f8-4414-b522-20b0d77c4c05.png)

**Progress Indicators**

https://user-images.githubusercontent.com/15972415/201532618-7cf7d894-9b9c-4fb9-9b70-fc08f2f5da90.mp4

**Run Widget**

<img width="1056" alt="Screenshot 2022-11-13 at 10 11 53 AM" src="https://user-images.githubusercontent.com/15972415/201532638-62ac57f8-3c44-4efe-8aed-2057424c39de.png">
<img width="1056" alt="Screenshot 2022-11-13 at 10 11 57 AM" src="https://user-images.githubusercontent.com/15972415/201532641-894ca75c-77c2-4838-a03c-16c12112091f.png">


