### PR TITLE
v5.7.2 - Actually makes NewUI Run Widget Usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Unreleased
 
+#### 5.7.2
+
+- Actually setting better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)
+
 #### 5.7.1
 
 - Better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 5.7.2
 
 - Actually setting better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)
+- Small Experimental UI consistency updates.
 
 #### 5.7.1
 

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -162,7 +162,10 @@
       "SearchField": {
         "background": "#282c34"
       },
-      "shortcutForeground": "accentColor"
+      "shortcutForeground": "accentColor",
+      "ToolTip": {
+        "background": "#323844"
+      }
     },
 
     "EditorPane.inactiveBackground": "#282c34",
@@ -213,7 +216,10 @@
 
     "MainToolbar": {
       "inactiveBackground": "#282c34",
-      "background": "backgroundColor"
+      "background": "backgroundColor",
+      "Dropdown": {
+        "hoverBackground": "#3d424b"
+      }
     },
 
     "Notification": {

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -275,11 +275,6 @@
         "updateBorderColor": "accentColor"
       },
 
-      "RunWidget": {
-        "foreground": "#eef3ff",
-        "background": "accentColor"
-      },
-
       "SearchField": {
         "background": "#282c34",
         "borderColor": "#1b1d21"
@@ -316,6 +311,12 @@
       "failedEndColor": "#bd3c5f",
       "passedColor": "#2b4242",
       "passedEndColor": "#239E62"
+    },
+
+    "RunWidget": {
+      "foreground": "#eef3ff",
+      "separatorColor": "#eef3ff",
+      "background": "accentColor"
     },
 
     "SearchEverywhere": {

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -14,6 +14,7 @@ val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
           <li>More Usable Experimental UI Run Widget</li>
+          <li>Small Experimental UI consistency updates.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>

--- a/src/main/kotlin/com/markskelton/notification/Notifications.kt
+++ b/src/main/kotlin/com/markskelton/notification/Notifications.kt
@@ -14,7 +14,6 @@ val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
           <li>More Usable Experimental UI Run Widget</li>
-          <li>More Visible Jupyter Notebook progression bar.</li>
       </ul>
       <br>Please see the <a href="https://github.com/one-dark/jetbrains-one-dark-theme/blob/master/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
## Changes

- Actually setting better foreground contrast for the experimental UI run widget and also coloring the inactive run widget. [#271](https://github.com/one-dark/jetbrains-one-dark-theme/issues/271)

## Motivation

Actually closes #271 

## Screens

<img width="1127" alt="Screenshot 2022-12-01 at 8 20 55 PM" src="https://user-images.githubusercontent.com/15972415/205200877-1e73d55b-034d-4604-acd0-4e5be74628be.png">
