### PR TITLE
Add "One Dark Italic Variables" theme

### DIFF
--- a/buildSrc/src/main/kotlin/themes/Groups.kt
+++ b/buildSrc/src/main/kotlin/themes/Groups.kt
@@ -4,7 +4,7 @@ import toOptional
 
 
 enum class Groups(val value: String) {
-  ATTRIBUTES("attributes"), COMMENTS("comments"), KEYWORDS("keywords")
+  ATTRIBUTES("attributes"), COMMENTS("comments"), KEYWORDS("keywords"), IDENTIFIERS("identifiers")
 }
 
 private val groupMappings = Groups.values()

--- a/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
+++ b/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
@@ -45,11 +45,13 @@ open class ThemeConstructor : DefaultTask() {
     private val gson = GsonBuilder().setPrettyPrinting().create()
     private const val REGULAR = "One Dark"
     private const val ITALIC = "One Dark Italic"
+    private const val ITALIC_VARS = "One Dark Italic Variables"
     private const val VIVID = "One Dark Vivid"
     private const val VIVID_ITALIC = "One Dark Vivid Italic"
     val THEMES = mapOf(
       "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" to REGULAR,
       "1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" to ITALIC,
+      "ef11f0df-57cd-4e48-b739-302cb489487b" to ITALIC_VARS,
       "4b6007f7-b596-4ee2-96f9-968d3d3eb392" to VIVID,
       "4f556d32-83cb-4b8b-9932-c4eccc4ce3af" to VIVID_ITALIC
     )
@@ -77,6 +79,13 @@ open class ThemeConstructor : DefaultTask() {
         GroupStyling.REGULAR.value,
       )
       ITALIC -> ThemeSettings(
+        false,
+        GroupStyling.ITALIC.value,
+        GroupStyling.ITALIC.value,
+        GroupStyling.ITALIC.value,
+        GroupStyling.ITALIC.value,
+      )
+      ITALIC_VARS -> ThemeSettings(
         false,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value,

--- a/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
+++ b/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
@@ -73,25 +73,29 @@ open class ThemeConstructor : DefaultTask() {
         false,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value,
-        GroupStyling.REGULAR.value
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
       )
       ITALIC -> ThemeSettings(
         false,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
         GroupStyling.ITALIC.value,
-        GroupStyling.ITALIC.value,
-        GroupStyling.ITALIC.value
       )
       VIVID -> ThemeSettings(
         true,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value,
-        GroupStyling.REGULAR.value
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
       )
       VIVID_ITALIC -> ThemeSettings(
         true,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
         GroupStyling.ITALIC.value,
-        GroupStyling.ITALIC.value,
-        GroupStyling.ITALIC.value
       )
       else -> throw IllegalArgumentException("Bro, I don't know what theme is $themeName")
     }
@@ -241,6 +245,7 @@ open class ThemeConstructor : DefaultTask() {
       Groups.ATTRIBUTES -> themeSettings.attributesStyle
       Groups.COMMENTS -> themeSettings.commentStyle
       Groups.KEYWORDS -> themeSettings.keywordStyle
+      Groups.IDENTIFIERS -> themeSettings.identifierStyle
     }.toGroupStyle()
 
   private fun matchesThemeSetting(

--- a/buildSrc/src/main/kotlin/themes/ThemeSettings.kt
+++ b/buildSrc/src/main/kotlin/themes/ThemeSettings.kt
@@ -5,5 +5,6 @@ data class ThemeSettings (
   val isVivid: Boolean = false,
   val commentStyle: String = GroupStyling.REGULAR.value,
   val keywordStyle: String = GroupStyling.REGULAR.value,
-  val attributesStyle: String = GroupStyling.REGULAR.value
+  val attributesStyle: String = GroupStyling.REGULAR.value,
+  val identifierStyle: String = GroupStyling.REGULAR.value
 )

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -2440,6 +2440,12 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="org.rust.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
+      </value>
+    </option>
     <option name="org.rust.PRIMITIVE_TYPE">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -77,6 +77,7 @@
     <option name="APACHE_CONFIG.IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="$purple$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="BAD_CHARACTER">
@@ -549,6 +550,7 @@
     <option name="DART_LOCAL_FUNCTION_DECLARATION">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DART_LOCAL_FUNCTION_REFERENCE">
@@ -637,26 +639,31 @@
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_GLOBAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="$coral$" />
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="$lightWhite$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_INTERFACE_NAME">
@@ -702,6 +709,7 @@
     <option name="DEFAULT_PARAMETER">
       <value>
         <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="DEFAULT_REASSIGNED_LOCAL_VARIABLE"/>
@@ -716,11 +724,18 @@
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
+      </value>
+    </option>
+    <option name="DEFAULT_INSTANCE_METHOD">
+      <value>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
         <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -800,6 +815,7 @@
     <option name="EDITORCONFIG_VARIABLE">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="EJS_OPEN">
@@ -1293,7 +1309,6 @@
     <option name="KOTLIN_TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="KOTLIN_TYPE_PARAMETER">
@@ -1772,6 +1787,7 @@
     <option name="RDOC_IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="$coral$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="RDOC_KEYWORD">
@@ -2354,6 +2370,7 @@
     <option name="com.plan9.IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="$fountainBlue$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="com.plan9.INSTRUCTION">
@@ -2389,6 +2406,7 @@
     <option name="org.rust.ENUM_VARIANT">
       <value>
         <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
     <option name="org.rust.LIFETIME">
@@ -2402,10 +2420,23 @@
         <option name="FOREGROUND" value="$malibu$"/>
       </value>
     </option>
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="org.rust.MUT_BINDING"/>
+    <option name="org.rust.METHOD_CALL">
+      <value>
+        <option name="FOREGROUND" value="$malibu$"/>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="org.rust.MUT_BINDING">
+      <value>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
+        <option name="EFFECT_COLOR" value="bca5c4" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="org.rust.MUT_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="$whiskey$"/>
+        <option name="EFFECT_COLOR" value="bca5c4" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="org.rust.PRIMITIVE_TYPE">
@@ -2419,7 +2450,6 @@
     <option name="org.rust.TYPE_ALIAS">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>
-        <option name="FONT_TYPE" value="%italic%"/>
       </value>
     </option>
     <option name="org.rust.TYPE_PARAMETER">

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -2435,6 +2435,7 @@
     </option>
     <option name="org.rust.MUT_PARAMETER">
       <value>
+        <option name="FONT_TYPE" value="%theme^identifiers%"/>
         <option name="EFFECT_COLOR" value="bca5c4" />
         <option name="EFFECT_TYPE" value="1" />
       </value>

--- a/buildSrc/templates/one-dark.template.xml
+++ b/buildSrc/templates/one-dark.template.xml
@@ -2446,6 +2446,7 @@
         <option name="FONT_TYPE" value="%theme^identifiers%"/>
       </value>
     </option>
+    <option baseAttributes="DEFAULT_FUNCTION_CALL" name="org.rust.FUNCTION_CALL"/>
     <option name="org.rust.PRIMITIVE_TYPE">
       <value>
         <option name="FOREGROUND" value="$chalky$"/>

--- a/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
+++ b/src/main/kotlin/com/markskelton/OneDarkThemeManager.kt
@@ -11,7 +11,7 @@ import com.markskelton.settings.ThemeSettings
 import java.util.*
 
 enum class OneDarkThemes {
-  REGULAR, ITALIC, VIVID, VIVID_ITALIC
+  REGULAR, ITALIC, ITALIC_VARS, VIVID, VIVID_ITALIC
 }
 
 object OneDarkThemeManager {
@@ -19,6 +19,7 @@ object OneDarkThemeManager {
   val THEMES = mapOf(
     "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" to OneDarkThemes.REGULAR,
     "1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" to OneDarkThemes.ITALIC,
+    "ef11f0df-57cd-4e48-b739-302cb489487b" to OneDarkThemes.ITALIC_VARS,
     "4b6007f7-b596-4ee2-96f9-968d3d3eb392" to OneDarkThemes.VIVID,
     "4f556d32-83cb-4b8b-9932-c4eccc4ce3af" to OneDarkThemes.VIVID_ITALIC
   )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,7 @@
     <postStartupActivity implementation="com.markskelton.OneDarkTheme"/>
     <themeProvider id="f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" path="/themes/one_dark.theme.json"/>
     <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>
+    <themeProvider id="ef11f0df-57cd-4e48-b739-302cb489487b" path="/themes/one_dark_italic_variables.theme.json"/>
     <themeProvider id="4b6007f7-b596-4ee2-96f9-968d3d3eb392" path="/themes/one_dark_vivid.theme.json"/>
     <themeProvider id="4f556d32-83cb-4b8b-9932-c4eccc4ce3af" path="/themes/one_dark_vivid_italic.theme.json"/>
   </extensions>


### PR DESCRIPTION
It's like "One Dark Italic", but only uses italic for variables (with runtime-available values).

The intent is to make the theme more user-friendly for languages like Rust which have a strict distinction between runtime values and compile time types (the latter includes const generic parameters which sure LOOK like regular values--but they aren't).