### PR TITLE
Add new UI variant for One Dark Theme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'one-dark-theme-plugin'
-    id 'org.jetbrains.intellij' version '1.9.0'
+    id 'org.jetbrains.intellij' version '1.15.0'
     id 'org.jetbrains.kotlin.jvm' version '1.7.10'
     id 'org.jlleitschuh.gradle.ktlint' version '8.2.0'
     id 'org.kordamp.gradle.markdown' version '2.2.0'
@@ -24,7 +24,7 @@ configurations {
 }
 
 intellij {
-  version.set('2021.3.1')
+  version.set('2022.3')
   type.set('IU')
   downloadSources.set(true)
   updateSinceUntilBuild.set(true)

--- a/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
+++ b/buildSrc/src/main/kotlin/themes/ThemeConstructor.kt
@@ -50,7 +50,11 @@ open class ThemeConstructor : DefaultTask() {
     private const val ITALIC = "One Dark Italic"
     private const val VIVID = "One Dark Vivid"
     private const val VIVID_ITALIC = "One Dark Vivid Italic"
+
+    // new UI
+    private const val REGULAR_NEW_UI = "One Dark New UI"
     val THEMES = mapOf(
+      "1fa63ea1-a161-4d01-b488-d4a6b2d4c10e" to REGULAR_NEW_UI,
       "f92a0fa7-1a98-47cd-b5cb-78ff67e6f4f3" to REGULAR,
       "1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" to ITALIC,
       "4b6007f7-b596-4ee2-96f9-968d3d3eb392" to VIVID,
@@ -65,7 +69,7 @@ open class ThemeConstructor : DefaultTask() {
     THEMES.entries.forEach {
       constructNewTheme(getSettings(it.value), OneDarkThemeDefinition(
         it.key,
-        it.value
+        it.value,
       ))
     }
   }
@@ -73,28 +77,35 @@ open class ThemeConstructor : DefaultTask() {
   private fun getSettings(themeName: String): ThemeSettings {
     return when (themeName) {
       REGULAR -> ThemeSettings(
-        false,
+        false, false,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value
       )
       ITALIC -> ThemeSettings(
-        false,
+        false, false,
         GroupStyling.ITALIC.value,
         GroupStyling.ITALIC.value,
         GroupStyling.ITALIC.value
       )
       VIVID -> ThemeSettings(
-        true,
+        true, false,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value,
         GroupStyling.REGULAR.value
       )
       VIVID_ITALIC -> ThemeSettings(
-        true,
+        true, false,
         GroupStyling.ITALIC.value,
         GroupStyling.ITALIC.value,
         GroupStyling.ITALIC.value
+      )
+
+      REGULAR_NEW_UI -> ThemeSettings(
+        false, true,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value,
+        GroupStyling.REGULAR.value
       )
       else -> throw IllegalArgumentException("Bro, I don't know what theme is $themeName")
     }
@@ -115,21 +126,25 @@ open class ThemeConstructor : DefaultTask() {
       "${createFileName(themeDefinition.name)}.xml"
     )
     buildNewEditorScheme(themeSettings, newEditorSchemeFile, themeDefinition)
-    buildThemeJson(themeDefinition, Paths.get(
-      assetsDirectory.toAbsolutePath().toString(),
-      "${createFileName(themeDefinition.name)}.theme.json"))
+    buildThemeJson(
+      themeSettings,
+      themeDefinition, Paths.get(
+        assetsDirectory.toAbsolutePath().toString(),
+        "${createFileName(themeDefinition.name)}.theme.json"))
   }
 
   private fun buildThemeJson(
+    themeSettings: ThemeSettings,
     themeDefinition: OneDarkThemeDefinition,
     destinationFile: Path
   ) {
+    val templateFile = if (themeSettings.newUi) "oneDark-newUi.template.theme.json" else "oneDark.template.theme.json"
     val themeJsonTemplate: MutableMap<String, Any> =
       Files.newInputStream(Paths.get(
         project.rootDir.absolutePath,
         "buildSrc",
         "templates",
-        "oneDark.template.theme.json"
+        templateFile
       ))
         .use {
           gson.fromJson<MutableMap<String, Any>>(JsonReader(it.reader()),

--- a/buildSrc/src/main/kotlin/themes/ThemeSettings.kt
+++ b/buildSrc/src/main/kotlin/themes/ThemeSettings.kt
@@ -3,6 +3,7 @@ package themes
 
 data class ThemeSettings (
   val isVivid: Boolean = false,
+  val newUi: Boolean = false,
   val commentStyle: String = GroupStyling.REGULAR.value,
   val keywordStyle: String = GroupStyling.REGULAR.value,
   val attributesStyle: String = GroupStyling.REGULAR.value

--- a/buildSrc/templates/oneDark-newUi.template.theme.json
+++ b/buildSrc/templates/oneDark-newUi.template.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "One Dark",
+  "name": "One Dark New UI",
   "dark": true,
   "author": "Mark Skelton",
   "editorScheme": "/themes/one_dark.xml",
@@ -118,7 +118,7 @@
       }
     },
 
-    "ComboPopup.border": "1,1,1,1,2d3137",
+    "ComboPopup.border": "1,1,1,1,#2d3137",
 
     "CompletionPopup":  {
       "background": "#3d424b",
@@ -162,15 +162,13 @@
       "SearchField": {
         "background": "#282c34"
       },
-      "shortcutForeground": "accentColor",
-      "ToolTip": {
-        "background": "#323844"
-      }
+      "shortcutForeground": "accentColor"
     },
 
     "EditorPane.inactiveBackground": "#282c34",
 
     "EditorTabs": {
+      "underlineArc": "4",
       "underlinedTabBackground": "#3d424b"
     },
 
@@ -196,12 +194,6 @@
       "successForeground": "#89ca78"
     },
 
-    "Lesson": {
-      "Tooltip.background" : "#3d424b",
-      "Tooltip.spanBackground" : "accentColor",
-      "Tooltip.foreground" : "#ffffff"
-    },
-
     "Link": {
       "activeForeground": "#6494ed",
       "hoverForeground": "#6494ed",
@@ -210,15 +202,21 @@
     },
 
     "List": {
+      "rowHeight": 24,
+      "border": "4,0,4,0",
       "selectionBackground": "#4d78cc",
-      "selectionForeground": "#ffffff"
+      "selectionForeground": "#ffffff",
+      "Button": {
+        "separatorInset": 4,
+        "leftRightInset": 8
+      }
     },
 
     "MainToolbar": {
-      "inactiveBackground": "#282c34",
+      "separatorColor": "separatorColor",
       "background": "backgroundColor",
-      "Dropdown": {
-        "hoverBackground": "#3d424b"
+      "Icon": {
+        "insets": "5,5,5,5"
       }
     },
 
@@ -287,8 +285,7 @@
       },
 
       "SearchField": {
-        "background": "#282c34",
-        "borderColor": "#1b1d21"
+        "background": "#282c34"
       },
 
       "SectionHeader.background": "#414855",
@@ -325,9 +322,7 @@
     },
 
     "RunWidget": {
-      "foreground": "#eef3ff",
-      "separatorColor": "#eef3ff",
-      "background": "accentColor"
+      "foreground": "#eef3ff"
     },
 
     "SearchEverywhere": {
@@ -361,9 +356,9 @@
 
     "Settings.Spotlight.borderColor": "accentColor",
 
-    "StatusBar.background": "baseBackground",
-
     "TabbedPane": {
+      "tabHeight": 40,
+      "tabSelectionArc": 4,
       "underlineColor": "accentColor",
       "contentAreaColor": "#323844",
       "hoverColor": "#323844"
@@ -419,6 +414,7 @@
       },
 
       "Header": {
+        "font.size.offset": 0,
         "background": "#414855",
         "inactiveBackground": "#323844"
       },
@@ -432,15 +428,16 @@
 
     "TitlePane" : {
       "infoForeground": "infoForeground",
-      "inactiveInfoForeground": "#5C6370"
+      "inactiveInfoForeground": "#5C6370",
+      "Button.preferredSize": "44,40"
     },
 
     "Tree": {
       "selectionBackground": "#4d78cc",
       "modifiedItemForeground": "accentColor",
-      "selectionInactiveForeground": "foregroundColor",
-      "rowHeight": 20
       "foreground": "foregroundColor",
+      "rowHeight": 24,
+      "border": "4,12,4,12"
     },
 
     "ValidationTooltip": {
@@ -475,6 +472,8 @@
       "Details.background": "backgroundColor"
     }
   },
+
+  "IdeStatusBar.border": "4,4,4,4",
 
   "icons": {
     "ColorPalette": {

--- a/buildSrc/templates/oneDark-newUi.template.theme.json
+++ b/buildSrc/templates/oneDark-newUi.template.theme.json
@@ -1,0 +1,492 @@
+{
+  "name": "One Dark",
+  "dark": true,
+  "author": "Mark Skelton",
+  "editorScheme": "/themes/one_dark.xml",
+  "colors": {
+    "accentColor": "#568AF2",
+    "backgroundColor": "#21252b",
+    "borderColor": "#333841",
+    "infoForeground": "#7e8491",
+    "foregroundColor": "#abb2bf",
+    "notificationBackground": "#3d424b",
+    "selectionBackground": "#323844",
+    "selectionForeground": "#d7dae0"
+  },
+  "ui": {
+    "*": {
+      "background": "backgroundColor",
+      "foreground": "#abb2bf",
+
+      "infoForeground": "#5c6370",
+
+      "selectionBackground": {
+        "os.default": "selectionBackground",
+        "os.windows": "selectionBackground",
+        "os.mac": "selectionBackground"
+      },
+      "selectionForeground": {
+        "os.default": "selectionForeground",
+        "os.windows": "selectionForeground",
+        "os.mac": "selectionForeground"
+      },
+      "selectionInactiveBackground": "#2c313a",
+      "selectionBackgroundInactive": "#2c313a",
+
+      "disabledBackground": "backgroundColor",
+      "inactiveBackground": "backgroundColor",
+
+      "acceleratorForeground": "#E6E6E6",
+      "acceleratorSelectionForeground": "#E6E6E6",
+
+      "errorForeground": "#cd3359",
+
+      "borderColor": "#333841",
+      "disabledBorderColor": "#2d3137",
+      "focusColor": "backgroundColor",
+      "focusedBorderColor": "accentColor",
+
+      "separatorColor": "#32363c"
+    },
+
+    "ActionButton": {
+      "hoverBackground": "#3d424b",
+      "hoverBorderColor": "#3d424b",
+      "pressedBackground": "#3f444d",
+      "pressedBorderColor": "#3f444d"
+    },
+
+    "BookmarkIcon.background": "#d9a343",
+
+    "BookmarkMnemonicAssigned": {
+      "foreground": "#ffffff",
+      "background": "#4d78cc",
+      "borderColor": "#4d78cc"
+    },
+
+    "BookmarkMnemonicAvailable": {
+      "borderColor": "borderColor",
+      "foreground": "#a0a7b4",
+      "background": "#3d424b"
+    },
+
+    "BookmarkMnemonicCurrent": {
+      "borderColor": "accentColor",
+      "foreground": "#a0a7b4",
+      "background": "#323844"
+    },
+
+    "BookmarkMnemonicIcon": {
+      "foreground": "#a0a7b4",
+      "background": "#3d424b",
+      "borderColor": "accentColor"
+    },
+
+    "Button": {
+      "foreground": "#a0a7b4",
+      "startBackground": "#3d424b",
+      "endBackground": "#3d424b",
+      "startBorderColor": "#464c55",
+      "endBorderColor": "#464c55",
+      "shadowColor": "backgroundColor",
+      "focusedBorderColor": "#646a73",
+
+      "default": {
+        "foreground": "#ffffff",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusedBorderColor": "#4269b9",
+        "focusColor": "#4269b9"
+      }
+    },
+
+    "Borders": {
+      "color": "#333841",
+      "ContrastBorderColor": "#333841"
+    },
+
+    "ComboBox": {
+      "nonEditableBackground": "#333841",
+      "background": "#333841",
+      "selectionBackground": "#4d78cc",
+      "ArrowButton": {
+        "iconColor": "#abb2bf",
+        "disabledIconColor": "#2c313a",
+        "nonEditableBackground": "#333841"
+      }
+    },
+
+    "ComboPopup.border": "1,1,1,1,2d3137",
+
+    "CompletionPopup":  {
+      "background": "#3d424b",
+      "selectionBackground": "#2c313a",
+      "matchForeground": "accentColor"
+    },
+
+    "ComplexPopup": {
+      "Header": {
+        "background": "backgroundColor"
+      }
+    },
+
+    "Component": {
+      "errorFocusColor": "#802d43",
+      "inactiveErrorFocusColor": "#522530",
+      "warningFocusColor": "#8c812b",
+      "inactiveWarningFocusColor": "#47441f"
+    },
+
+    "Counter": {
+      "background": "#3d424b",
+      "foreground": "#abb2bf"
+    },
+
+    "DefaultTabs": {
+      "underlineColor": "accentColor",
+      "inactiveUnderlineColor": "#4269b9",
+      "hoverBackground": "#323844"
+    },
+
+    "DragAndDrop": {
+      "areaForeground": "#abb2bf",
+      "areaBackground": "#323844",
+      "areaBorderColor": "#333841"
+    },
+
+    "Editor": {
+      "background": "#282c34",
+      "foreground": "#abb2bf",
+      "SearchField": {
+        "background": "#282c34"
+      },
+      "shortcutForeground": "accentColor",
+      "ToolTip": {
+        "background": "#323844"
+      }
+    },
+
+    "EditorPane.inactiveBackground": "#282c34",
+
+    "EditorTabs": {
+      "underlinedTabBackground": "#3d424b"
+    },
+
+    "FileColor": {
+      "Yellow": "#3d3026",
+      "Green": "#293a24",
+      "Blue": "#24354f",
+      "Violet": "#2d1942",
+      "Orange": "#3d3026",
+      "Rose": "#3d1e2b"
+    },
+
+    "GotItTooltip" : {
+      "foreground" : "#abb2bf",
+      "background" : "#3d424b",
+      "borderColor" : "#53565f",
+      "linkForeground" : "#6494ed",
+      "shortcutForeground" : "infoForeground"
+    },
+
+    "Label": {
+      "infoForeground": "infoForeground",
+      "successForeground": "#89ca78"
+    },
+
+    "Lesson": {
+      "Tooltip.background" : "#3d424b",
+      "Tooltip.spanBackground" : "accentColor",
+      "Tooltip.foreground" : "#ffffff"
+    },
+
+    "Link": {
+      "activeForeground": "#6494ed",
+      "hoverForeground": "#6494ed",
+      "pressedForeground": "#6494ed",
+      "visitedForeground": "#6494ed"
+    },
+
+    "List": {
+      "selectionBackground": "#4d78cc",
+      "selectionForeground": "#ffffff"
+    },
+
+    "MainToolbar": {
+      "inactiveBackground": "#282c34",
+      "background": "backgroundColor",
+      "Dropdown": {
+        "hoverBackground": "#3d424b"
+      }
+    },
+
+    "MemoryIndicator": {
+      "allocatedBackground": "#304676",
+      "usedBackground": "#3a5a9c"
+    },
+
+    "Notification": {
+      "background": "notificationBackground",
+      "borderColor": "#53565f",
+
+      "errorForeground": "#abb2bf",
+      "errorBackground": "#4d232e",
+      "errorBorderColor": "#692746",
+
+      "MoreButton": {
+        "background": "#2f343c",
+        "innerBorderColor": "#53565f"
+      },
+
+      "ToolWindow": {
+        "informativeForeground": "#abb2bf",
+        "informativeBackground": "#2e4280",
+        "informativeBorderColor": "#252555",
+
+        "warningForeground": "#abb2bf",
+        "warningBackground": "#735822",
+        "warningBorderColor": "#5f4422",
+
+        "errorForeground": "#abb2bf",
+        "errorBackground": "#802d43",
+        "errorBorderColor": "#552029"
+      }
+    },
+
+    "NotificationsToolwindow.newNotification.background" : "notificationBackground",
+    "NotificationsToolwindow.newNotification.hoverBackground" : "#3d424b",
+    "NotificationsToolwindow.Notification.hoverBackground" : "#3d424b",
+
+    "Panel.background": "backgroundColor",
+
+    "ParameterInfo": {
+      "background": "#3d424b",
+      "foreground": "#abb2bf",
+      "infoForeground": "#5c6370",
+      "currentParameterForeground": "#ffffff"
+    },
+
+    "Plugins": {
+      "background": "backgroundColor",
+      "disabledForeground": "#5c6370",
+      "hoverBackground": "#323844",
+      "lightSelectionBackground": "#323844",
+      "tagBackground": "#414855",
+      "tagForeground": "#abb2bf",
+
+      "Button": {
+        "installForeground": "accentColor",
+        "installBorderColor":"accentColor",
+        "installFillForeground": "#ffffff",
+        "installFillBackground": "accentColor",
+        "updateForeground":"#ffffff",
+        "updateBackground": "accentColor",
+        "updateBorderColor": "accentColor"
+      },
+
+      "SearchField": {
+        "background": "#282c34",
+        "borderColor": "#1b1d21"
+      },
+
+      "SectionHeader.background": "#414855",
+
+      "Tab": {
+        "selectedForeground": "#abb2bf",
+        "selectedBackground": "#323844",
+        "hoverBackground": "#323844"
+      }
+    },
+
+    "Popup": {
+      "background": "#282c34",
+      "paintBorder": false,
+      "borderColor": "#21252b",
+      "Toolbar.borderColor": "#3d424b",
+      "Header.activeBackground": "#414855",
+      "Header.inactiveBackground": "#2c313a",
+      "Advertiser": {
+        "foreground": "#5c6370",
+        "borderColor": "#2d3137"
+      }
+    },
+
+    "ProgressBar": {
+      "trackColor": "#1D1D26",
+      "progressColor": "accentColor",
+      "indeterminateStartColor": "#313469",
+      "indeterminateEndColor": "accentColor",
+      "failedColor": "#472c33",
+      "failedEndColor": "#bd3c5f",
+      "passedColor": "#2b4242",
+      "passedEndColor": "#239E62"
+    },
+
+    "RunWidget": {
+      "foreground": "#eef3ff",
+      "separatorColor": "#eef3ff",
+      "background": "accentColor"
+    },
+
+    "SearchEverywhere": {
+      "Advertiser.foreground": "#5c6370",
+      "Header.background": "backgroundColor",
+
+      "SearchField":{
+        "background": "#282c34",
+        "borderColor": "#1b1d21"
+      },
+
+      "Tab": {
+        "selectedForeground": "#abb2bf",
+        "selectedBackground": "#323844"
+      }
+    },
+
+    "SearchMatch": {
+      "startBackground": "accentColor",
+      "endBackground": "accentColor"
+    },
+
+    "SidePanel.background": "backgroundColor",
+
+    "SpeedSearch": {
+      "foreground": "#abb2bf",
+      "borderColor": "#3d424b",
+      "background": "#3d424b",
+      "errorForeground": "#e06c75"
+    },
+
+    "Settings.Spotlight.borderColor": "accentColor",
+
+    "StatusBar.background": "baseBackground",
+
+    "TabbedPane": {
+      "underlineColor": "accentColor",
+      "contentAreaColor": "#323844",
+      "hoverColor": "#323844"
+    },
+
+    "Table": {
+      "background": "#282c34",
+      "stripeColor": "#2c313a",
+      "selectionForeground": "#ffffff",
+      "foreground": "#abb2bf",
+      "dropLineColor": "#abb2bf",
+      "focusCellForeground": "#abb2bf",
+      "gridColor": "#5c6370",
+      "lightSelectionInactiveForeground": "#abb2bf",
+      "lightSelectionForeground": "#abb2bf",
+      "selectionBackground": "#3d424b",
+      "selectionInactiveForeground": "#abb2bf",
+      "lightSelectionBackground": "#414855",
+      "lightSelectionInactiveBackground": "#323844"
+    },
+
+    "Tag.background": "#3d424b",
+
+    "TextArea": {
+      "background": "#282c34",
+      "selectionBackground": "#414855"
+    },
+
+    "TextField": {
+      "background": "#282c34",
+      "selectionBackground": "#414855"
+    },
+
+    "ToggleButton": {
+      "onForeground": "#ffffff",
+      "onBackground": "accentColor",
+      "offForeground": "#9f9fa6",
+      "offBackground": "#3d424b",
+      "borderColor":  "#3d424b",
+      "buttonColor": "#5c6370"
+    },
+
+    "ToolTip": {
+      "background": "#3d424b"
+    },
+
+    "ToolWindow": {
+      "background": "backgroundColor",
+      "Button": {
+        "hoverBackground": "#323844",
+        "selectedBackground": "#3d424b",
+        "selectedForeground": "#abb2bf"
+      },
+
+      "Header": {
+        "background": "#414855",
+        "inactiveBackground": "#323844"
+      },
+
+      "HeaderTab": {
+        "hoverBackground": "#323844",
+        "hoverInactiveBackground": "#3d424b",
+        "selectedBackground": "#323844",
+        "selectedInactiveBackground": "#3d424b"
+      }
+    },
+
+    "TitlePane" : {
+      "infoForeground": "infoForeground",
+      "inactiveInfoForeground": "#5C6370"
+    },
+
+    "Tree": {
+      "selectionBackground": "#4d78cc",
+      "modifiedItemForeground": "accentColor",
+      "selectionInactiveForeground": "foregroundColor",
+      "rowHeight": 20
+    },
+
+    "ValidationTooltip": {
+      "errorBackground": "#802d43",
+      "errorBorderColor": "#802d43",
+      "warningBackground": "#735822",
+      "warningBorderColor": "#5f4422"
+    },
+
+    "VersionControl": {
+      "Log.Commit": {
+        "currentBranchBackground": "#282c35",
+        "hoveredBackground": "#2c313c",
+        "unmatchedForeground": "#5c6370"
+      },
+
+      "RefLabel": {
+        "backgroundBrightness": 0.3,
+        "backgroundBase": "#5c6370",
+        "foreground": "#abb2bf"
+      }
+    },
+
+    "WelcomeScreen": {
+      "borderColor": "borderColor",
+      "Projects": {
+        "actions.background": "#323844",
+        "selectionInactiveBackground": "#2c313a"
+      },
+      "separatorColor": "#2c313a",
+      "SidePanel.background": "#282c34",
+      "Details.background": "backgroundColor"
+    }
+  },
+
+  "icons": {
+    "ColorPalette": {
+      "Checkbox.Background.Default.Dark": "#282c34",
+      "Checkbox.Border.Default.Dark": "#414855",
+      "Checkbox.Foreground.Selected.Dark": "#abb2bf",
+      "Checkbox.Focus.Wide.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Default.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Selected.Dark": "#568AF2",
+      "Checkbox.Background.Disabled.Dark": "#21252b",
+      "Checkbox.Border.Disabled.Dark": "#2c313a",
+      "Checkbox.Foreground.Disabled.Dark": "#5c6370"
+    }
+  }
+}

--- a/buildSrc/templates/oneDark-newUi.template.theme.json
+++ b/buildSrc/templates/oneDark-newUi.template.theme.json
@@ -153,7 +153,7 @@
     "DragAndDrop": {
       "areaForeground": "#abb2bf",
       "areaBackground": "#323844",
-      "areaBorderColor": "#333841"
+      "borderColor": "#333841"
     },
 
     "Editor": {
@@ -426,7 +426,6 @@
       "HeaderTab": {
         "hoverBackground": "#323844",
         "hoverInactiveBackground": "#3d424b",
-        "selectedBackground": "#323844",
         "selectedInactiveBackground": "#3d424b"
       }
     },
@@ -441,6 +440,7 @@
       "modifiedItemForeground": "accentColor",
       "selectionInactiveForeground": "foregroundColor",
       "rowHeight": 20
+      "foreground": "foregroundColor",
     },
 
     "ValidationTooltip": {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,5 +22,6 @@
     <themeProvider id="1a92aa6f-c2f1-4994-ae01-6a78e43eeb24" path="/themes/one_dark_italic.theme.json"/>
     <themeProvider id="4b6007f7-b596-4ee2-96f9-968d3d3eb392" path="/themes/one_dark_vivid.theme.json"/>
     <themeProvider id="4f556d32-83cb-4b8b-9932-c4eccc4ce3af" path="/themes/one_dark_vivid_italic.theme.json"/>
+    <themeProvider id="1fa63ea1-a161-4d01-b488-d4a6b2d4c10e" path="/themes/one_dark_new_ui.theme.json"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Add new UI variant for One Dark Theme

#### Description

Adds a new UI version of one dark theme

#### Motivation and Context

I am a daily user of the new UI in IntelliJ and the regular one dark theme had different border/spacing than themes for the new UI.

#### Screenshots (if appropriate):

![image](https://github.com/one-dark/jetbrains-one-dark-theme/assets/11280210/70f343d4-561d-45b5-a8a2-c7b4807d989b)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the changelog with the new functionality.
