### PR TITLE
Add alpha-channel value on background colors while drag & drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 5.13.1
+
+- Added alpha-channel value on background colors while drag & drop to make it transparent like default Intellij themes
+
 #### 5.13.0
 
 - Added 2025.1 Build Support

--- a/buildSrc/templates/oneDark.template.theme.json
+++ b/buildSrc/templates/oneDark.template.theme.json
@@ -152,7 +152,7 @@
 
     "DragAndDrop": {
       "areaForeground": "#abb2bf",
-      "areaBackground": "#323844",
+      "areaBackground": "#abb2bf33",
       "areaBorderColor": "#333841"
     },
 

--- a/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/markskelton/settings/ThemeSettings.kt
@@ -14,7 +14,6 @@ class ThemeSettings : PersistentStateComponent<ThemeSettings>, Cloneable {
   companion object {
     val instance: ThemeSettings
       get() = ApplicationManager.getApplication().getService(ThemeSettings::class.java)
-
   }
 
   var version: String = "0.0.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
One Dark theme currently has no transparent feature when moving an editor tab using drag & drop.
This PR will make it happen.

#### Motivation and Context
This would make users feel more pleasant when moving editor tabs.
This transparent look is the default behavior when using Intellij's default theme like `Darcula`.

This closes #362 

@all-contributors please add @djkeh for code

#### Screenshots (if appropriate):
![after](https://github.com/user-attachments/assets/2f02793d-ae2f-4d2a-b0cb-ffbc3976ac9f)

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the changelog with the new functionality.
