### PR TITLE
Bumps github action cache version

### DIFF
--- a/.github/workflows/preMerge.yml
+++ b/.github/workflows/preMerge.yml
@@ -23,7 +23,7 @@ jobs:
         RELEASE_NOTES: '-This is a test and should not be released.\n-Also a test there might be a character minimum'
       # Cache Plugin Verifier IDEs
     - name: Setup Plugin Verifier IDEs Cache
-      uses: actions/cache@v3.0.8
+      uses: actions/cache@v4
       with:
         path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
         key: ${{ runner.os }}-plugin-verifier-${{ steps.properties.outputs.ideVersions }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 5.13.1
+
+- Github action/cache v4
+
 #### 5.13.0
 
 - Added 2025.1 Build Support


### PR DESCRIPTION
#### Description
Bumps  action cache version due to
https://github.com/one-dark/jetbrains-one-dark-theme/actions/runs/16730311815/job/47369682217?pr=366

#### Motivation and Context
actions/cache with versions lower than 4 starts failing
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the changelog with the new functionality.
