### PR TITLE
Updates active tab border color to not blend in with background

### DIFF
--- a/src/main/resources/one_dark_islands.theme.json
+++ b/src/main/resources/one_dark_islands.theme.json
@@ -121,8 +121,8 @@
     },
     "EditorTabs": {
       "background": "panelColor",
-      "underlinedBorderColor": "backgroundColor",
-      "underlinedTabBackground": "backgroundColor",
+      "underlinedBorderColor": "focusedBorderColor",
+      "underlinedTabBackground": "focusedBorderColor",
       "underlinedTabForeground": "#abb2bf",
       "underlineColor": "accentColor",
       "inactiveUnderlinedTabBorderColor": "borderColor",

--- a/src/main/resources/one_dark_islands_vivid.theme.json
+++ b/src/main/resources/one_dark_islands_vivid.theme.json
@@ -121,8 +121,8 @@
     },
     "EditorTabs": {
       "background": "panelColor",
-      "underlinedBorderColor": "backgroundColor",
-      "underlinedTabBackground": "backgroundColor",
+      "underlinedBorderColor": "focusedBorderColor",
+      "underlinedTabBackground": "focusedBorderColor",
       "underlinedTabForeground": "#bbbbbb",
       "underlineColor": "accentColor",
       "inactiveUnderlinedTabBorderColor": "borderColor",


### PR DESCRIPTION
Fixes #386. Before / after screenshots below

<details>
<summary>Before</summary>

<img width="986" height="762" alt="Screenshot 2026-01-28 at 11 50 13" src="https://github.com/user-attachments/assets/9abb6cf8-f696-4281-b1ec-6424eb441339" />
<img width="698" height="131" alt="Screenshot 2026-01-28 at 11 50 08" src="https://github.com/user-attachments/assets/4d4825c9-a675-4880-bfa9-99aee4611bea" />
<img width="1885" height="1373" alt="Screenshot 2026-01-28 at 11 50 04" src="https://github.com/user-attachments/assets/c46e6d41-cd52-40ee-899e-424949099b46" />


</details>

<details>
<summary>After</summary>

<img width="989" height="730" alt="Screenshot 2026-01-28 at 11 49 46" src="https://github.com/user-attachments/assets/c4ac192f-066b-489c-9d74-d7f9267070ce" />
<img width="1882" height="1369" alt="Screenshot 2026-01-28 at 11 49 53" src="https://github.com/user-attachments/assets/f967396d-f2d7-4c63-889f-e98bf0fef4e5" />
<img width="741" height="143" alt="Screenshot 2026-01-28 at 11 49 57" src="https://github.com/user-attachments/assets/16e35590-9163-439a-9369-1812cf9e893f" />


</details>