### PR TITLE
#388: Resolve "Vivid Islands odd grey rectangle on top right Toolbar"

### DIFF
--- a/src/main/resources/one_dark_islands.theme.json
+++ b/src/main/resources/one_dark_islands.theme.json
@@ -56,7 +56,7 @@
       "separatorColor": "borderColor"
     },
     "MainToolbar": {
-      "background": "panelColor",
+      "background": "backgroundColor",
       "inactiveBackground": "backgroundColor",
       "borderColor": "borderTransparent",
       "Dropdown": {

--- a/src/main/resources/one_dark_islands_vivid.theme.json
+++ b/src/main/resources/one_dark_islands_vivid.theme.json
@@ -56,7 +56,7 @@
       "separatorColor": "borderColor"
     },
     "MainToolbar": {
-      "background": "panelColor",
+      "background": "backgroundColor",
       "inactiveBackground": "backgroundColor",
       "borderColor": "borderTransparent",
       "Dropdown": {


### PR DESCRIPTION
Before: 
<img width="1920" height="1036" alt="grafik" src="https://github.com/user-attachments/assets/316ef6ff-08ac-4477-acf6-f47fede5e178" />


After:
<img width="1920" height="1036" alt="grafik" src="https://github.com/user-attachments/assets/b6f5cd7e-bea1-40b6-93f0-5b7f7f05cfa0" />
