### PR TITLE
Dependency updates, fix deprecated Checkbox color keys, adjust Windows inactiveAlpha

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,20 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v5
+      - name: Set up Java
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '26'
           cache: 'gradle'
 
-      - run: ./gradlew buildPlugin
+      - name: Build plugin
+        run: ./gradlew buildPlugin
 
-      - run: ./gradlew publishPlugin
+      - name: Publish plugin
+        run: ./gradlew publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '26'
+          java-version: '25'
           cache: 'gradle'
 
       - name: Build plugin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '26'
           cache: 'gradle'
 
       - run: ./gradlew buildPlugin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,19 @@
 name: Publish
+
 on:
   workflow_dispatch:
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v5
         with:
-          java-version: 25
+          distribution: 'temurin'
+          java-version: '25'
+          cache: 'gradle'
 
       - run: ./gradlew buildPlugin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [6.2.3]
+
+- Fix deprecated Checkbox color keys in Islands themes
+- Remove unsupported `Checkbox.Focus.Thin.*.Dark` keys in Islands themes
+- Set `inactiveAlpha` and `inactiveAlphaInStatusBar` to `0` on Windows for Islands themes (#393)
+
 ## [6.2.2]
 
 - Fix toolbar color for Islands theme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix deprecated Checkbox color keys in Islands themes
 - Remove unsupported `Checkbox.Focus.Thin.*.Dark` keys in Islands themes
-- Set `inactiveAlpha` and `inactiveAlphaInStatusBar` to `0` on Windows for Islands themes (#393)
+- Set `inactiveAlpha` and `inactiveAlphaInStatusBar` to `0` on Windows for Islands themes ([#393](https://github.com/one-dark/jetbrains-one-dark-theme/issues/393))
 
 ## [6.2.2]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2025, Mark Skelton
+Copyright (c) 2025-2026, Mark Skelton
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginSinceBuild = 252
 platformVersion = 2025.2.5
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.2.1
+gradleVersion = 9.4.1
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion = 6.2.2
 pluginSinceBuild = 252
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformVersion = 2025.2.5
+platformVersion = 2026.1
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.markskelton
 pluginName = One Dark Theme
 pluginRepositoryUrl = https://github.com/one-dark/jetbrains-one-dark-theme
-pluginVersion = 6.2.2
+pluginVersion = 6.2.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 252

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 changelog = "2.5.0"
 intelliJPlatform = "2.13.1"
-kotlin = "2.2.21"
+kotlin = "2.3.20"
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 changelog = "2.5.0"
-intelliJPlatform = "2.10.5"
+intelliJPlatform = "2.13.1"
 kotlin = "2.2.21"
 
 [plugins]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,10 +2,7 @@
     <id>com.markskelton.one-dark-theme</id>
     <name>One Dark Theme</name>
     <category>UI</category>
-
-  <vendor email="one-dark@mskelton.dev"
-          url="https://github.com/one-dark/jetbrains-one-dark-theme">Mark Skelton
-  </vendor>
+    <vendor email="one-dark@mskelton.dev" url="https://github.com/one-dark/jetbrains-one-dark-theme">Mark Skelton</vendor>
 
     <idea-version since-build="252.25557"/>
 

--- a/src/main/resources/one_dark_islands.theme.json
+++ b/src/main/resources/one_dark_islands.theme.json
@@ -41,10 +41,10 @@
       "borderWidth": 5,
       "borderWidth.compact": 4,
       "borderColor": "panelColor",
-      "inactiveAlpha": 0.12,
+      "inactiveAlpha": 0,
       "inactiveAlphaInStatusBar": {
         "os.mac": 0.2,
-        "os.windows": 0.2,
+        "os.windows": 0,
         "os.linux": 0.15
       }
     },

--- a/src/main/resources/one_dark_islands.theme.json
+++ b/src/main/resources/one_dark_islands.theme.json
@@ -279,13 +279,15 @@
   },
   "icons": {
     "ColorPalette": {
-      "Checkbox.Background.Default": "#282c34",
-      "Checkbox.Border.Default": "#414855",
-      "Checkbox.Foreground.Selected": "#abb2bf",
-      "Checkbox.Focus.Wide": "#568AF2",
-      "Checkbox.Background.Disabled": "#21252b",
-      "Checkbox.Border.Disabled": "#2c313a",
-      "Checkbox.Foreground.Disabled": "#5c6370"
+      "Checkbox.Background.Default.Dark": "#282c34",
+      "Checkbox.Border.Default.Dark": "#414855",
+      "Checkbox.Foreground.Selected.Dark": "#abb2bf",
+      "Checkbox.Focus.Wide.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Default.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Selected.Dark": "#568AF2",
+      "Checkbox.Background.Disabled.Dark": "#21252b",
+      "Checkbox.Border.Disabled.Dark": "#2c313a",
+      "Checkbox.Foreground.Disabled.Dark": "#5c6370"
     }
   }
 }

--- a/src/main/resources/one_dark_islands.theme.json
+++ b/src/main/resources/one_dark_islands.theme.json
@@ -279,15 +279,13 @@
   },
   "icons": {
     "ColorPalette": {
-      "Checkbox.Background.Default.Dark": "#282c34",
-      "Checkbox.Border.Default.Dark": "#414855",
-      "Checkbox.Foreground.Selected.Dark": "#abb2bf",
-      "Checkbox.Focus.Wide.Dark": "#568AF2",
-      "Checkbox.Focus.Thin.Default.Dark": "#568AF2",
-      "Checkbox.Focus.Thin.Selected.Dark": "#568AF2",
-      "Checkbox.Background.Disabled.Dark": "#21252b",
-      "Checkbox.Border.Disabled.Dark": "#2c313a",
-      "Checkbox.Foreground.Disabled.Dark": "#5c6370"
+      "Checkbox.Background.Default": "#282c34",
+      "Checkbox.Border.Default": "#414855",
+      "Checkbox.Foreground.Selected": "#abb2bf",
+      "Checkbox.Focus.Wide": "#568AF2",
+      "Checkbox.Background.Disabled": "#21252b",
+      "Checkbox.Border.Disabled": "#2c313a",
+      "Checkbox.Foreground.Disabled": "#5c6370"
     }
   }
 }

--- a/src/main/resources/one_dark_islands_vivid.theme.json
+++ b/src/main/resources/one_dark_islands_vivid.theme.json
@@ -279,15 +279,13 @@
   },
   "icons": {
     "ColorPalette": {
-      "Checkbox.Background.Default.Dark": "#282c34",
-      "Checkbox.Border.Default.Dark": "#414855",
-      "Checkbox.Foreground.Selected.Dark": "#bbbbbb",
-      "Checkbox.Focus.Wide.Dark": "#568AF2",
-      "Checkbox.Focus.Thin.Default.Dark": "#568AF2",
-      "Checkbox.Focus.Thin.Selected.Dark": "#568AF2",
-      "Checkbox.Background.Disabled.Dark": "#21252b",
-      "Checkbox.Border.Disabled.Dark": "#2c313a",
-      "Checkbox.Foreground.Disabled.Dark": "#5c6370"
+      "Checkbox.Background.Default": "#282c34",
+      "Checkbox.Border.Default": "#414855",
+      "Checkbox.Foreground.Selected": "#bbbbbb",
+      "Checkbox.Focus.Wide": "#568AF2",
+      "Checkbox.Background.Disabled": "#21252b",
+      "Checkbox.Border.Disabled": "#2c313a",
+      "Checkbox.Foreground.Disabled": "#5c6370"
     }
   }
 }

--- a/src/main/resources/one_dark_islands_vivid.theme.json
+++ b/src/main/resources/one_dark_islands_vivid.theme.json
@@ -41,10 +41,10 @@
       "borderWidth": 5,
       "borderWidth.compact": 4,
       "borderColor": "panelColor",
-      "inactiveAlpha": 0.12,
+      "inactiveAlpha": 0,
       "inactiveAlphaInStatusBar": {
         "os.mac": 0.2,
-        "os.windows": 0.2,
+        "os.windows": 0,
         "os.linux": 0.15
       }
     },

--- a/src/main/resources/one_dark_islands_vivid.theme.json
+++ b/src/main/resources/one_dark_islands_vivid.theme.json
@@ -279,13 +279,15 @@
   },
   "icons": {
     "ColorPalette": {
-      "Checkbox.Background.Default": "#282c34",
-      "Checkbox.Border.Default": "#414855",
-      "Checkbox.Foreground.Selected": "#bbbbbb",
-      "Checkbox.Focus.Wide": "#568AF2",
-      "Checkbox.Background.Disabled": "#21252b",
-      "Checkbox.Border.Disabled": "#2c313a",
-      "Checkbox.Foreground.Disabled": "#5c6370"
+      "Checkbox.Background.Default.Dark": "#282c34",
+      "Checkbox.Border.Default.Dark": "#414855",
+      "Checkbox.Foreground.Selected.Dark": "#bbbbbb",
+      "Checkbox.Focus.Wide.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Default.Dark": "#568AF2",
+      "Checkbox.Focus.Thin.Selected.Dark": "#568AF2",
+      "Checkbox.Background.Disabled.Dark": "#21252b",
+      "Checkbox.Border.Disabled.Dark": "#2c313a",
+      "Checkbox.Foreground.Disabled.Dark": "#5c6370"
     }
   }
 }


### PR DESCRIPTION
## Theme fixes (`one_dark_islands`, `one_dark_islands_vivid`)
1. Replaced deprecated `.Dark` suffix Checkbox color keys with new equivalents required by the new UI:
   ```text
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Background.Default.Dark is deprecated for new UI themes, use Checkbox.Background.Default instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Border.Default.Dark is deprecated for new UI themes, use Checkbox.Border.Default instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Foreground.Selected.Dark is deprecated for new UI themes, use Checkbox.Foreground.Selected instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Focus.Wide.Dark is deprecated for new UI themes, use Checkbox.Focus.Wide instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Background.Disabled.Dark is deprecated for new UI themes, use Checkbox.Background.Disabled instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Border.Disabled.Dark is deprecated for new UI themes, use Checkbox.Border.Disabled instead
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: Checkbox.Foreground.Disabled.Dark is deprecated for new UI themes, use Checkbox.Foreground.Disabled instead
   ```
2. Removed unsupported `Checkbox.Focus.Thin.*.Dark` keys:
   ```text
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: color key Checkbox.Focus.Thin.Default.Dark is not supported and therefore ignored
   2026-04-08 19:42:36,944 [    838]   WARN - #c.i.i.u.UiThemePaletteCheckBoxScope - Theme One Dark Islands: color key Checkbox.Focus.Thin.Selected.Dark is not supported and therefore ignored
   ```
3. Set `inactiveAlpha` and `inactiveAlphaInStatusBar` to `0` on Windows (fixes #393)
   | Before                                                                                                                 | After                                                                                                                 |
   |------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
   | <img width="666" alt="Before" src="https://github.com/user-attachments/assets/660a5375-4476-4d63-af3b-a645565208d7" /> | <img width="666" alt="After" src="https://github.com/user-attachments/assets/7f0af1e8-2aca-426e-b28f-62bb327bc1ef" /> |

## Dependencies
1. `intelliJPlatform`: `2.10.5` → `2.13.1`
2. `platformVersion`: `2025.2.5` → `2026.1`
3. Gradle: `9.2.1` → `9.4.1`
4. Kotlin: `2.2.21` → `2.3.20`
5. `jvmToolchain`: `21` → `25`

## GitHub Actions
1. `actions/checkout@v2` → `actions/checkout@v6`
2. `actions/setup-java@v1` → `actions/setup-java@v5`
3. Added `name:` to all steps

## Screenshot
<img width="1920" height="1032" alt="java_hw5f8fMS" src="https://github.com/user-attachments/assets/25cd6f6e-9279-484f-a2a6-77edb83add18" />
