### PR TITLE
Bump minimum IntelliJ Platform version to 2025.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [6.2.3]
 
+- Require minimum IntelliJ Platform 2025.3 (build 253); versions <=2025.2 do not support Islands themes
 - Fix deprecated Checkbox color keys in Islands themes
 - Remove unsupported `Checkbox.Focus.Thin.*.Dark` keys in Islands themes
 - Set `inactiveAlpha` and `inactiveAlphaInStatusBar` to `0` on Windows for Islands themes ([#393](https://github.com/one-dark/jetbrains-one-dark-theme/issues/393))

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginRepositoryUrl = https://github.com/one-dark/jetbrains-one-dark-theme
 pluginVersion = 6.2.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 252
+pluginSinceBuild = 253
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformVersion = 2026.1

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <category>UI</category>
     <vendor email="one-dark@mskelton.dev" url="https://github.com/one-dark/jetbrains-one-dark-theme">Mark Skelton</vendor>
 
-    <idea-version since-build="252.25557"/>
+    <idea-version since-build="253.3"/>
 
     <description><![CDATA[
         <p>One Dark theme for JetBrains.</p>


### PR DESCRIPTION
Versions `<=2025.2` do not support Islands themes anyway, so there is no reason to keep compatibility with them.                                                                                                                        
                                                            
## Changes
- Set `since-build` to `253.3` in `plugin.xml`
- Set `pluginSinceBuild` to `253` in `gradle.properties`

Version `v6.2.3` of the theme is ready for release.